### PR TITLE
removal and addition of constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 Dualization = "191a621a-6537-11e9-281d-650236a99e60"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
 Dualization = "~0.2.1"

--- a/src/bilevelJuMPExtension.jl
+++ b/src/bilevelJuMPExtension.jl
@@ -1,0 +1,170 @@
+macro delete_cons(model,cref)
+    model_string = string(model)
+    cref_string = string(cref)
+    s = quote
+        local con = $cref_string
+        # println(con)
+        local model_local = Meta.parse($model_string)
+        local semi_locals = Base.@locals # get the local vars within the loop
+        local model_fixed = remove_local_var(model_local,semi_locals)
+        local s = repr(eval(model_fixed))
+        local p = Regex("(?<=\\n)(.*\\bconstraint\\b.*\\b$con\\b.*)(?=\\n)")
+        # p = Regex("$con")
+        # println(p)
+        local snew = replace(s,p => "")
+        local model_new = Meta.parse(snew)#默认会套上一层quote "x" -> "quote x end"
+        eval(model_new)
+    end
+    return s
+end
+macro add_upper_cons(model,expression...)#Almost the same as add_lower_cons except for Upper()/Lower()
+    model_string = string(model)
+    expression_string = [string(e) for e in expression]
+    return quote
+    local model_local = Meta.parse($model_string)
+    local expression_local = [Meta.parse(x) for x in $expression_string]
+    @assert length($expression_string) <= 2
+    @assert length($expression_string) >= 1
+    local semi_locals = Base.@locals # get the local vars within the loop
+    local model_fixed = remove_local_var(model_local,semi_locals)
+    local s = repr(eval(model_fixed))
+    local p = r"\n.*return"
+    local blm = match(r"\b.*(?==.*Bilevel)",s).match
+    local vars_temp = [split(x.match," ")[3] for x in eachmatch(r"(?<=@variable).*",s)]
+    # println(vars_temp)
+    local vars = [Meta.parse(replace(x,r"(?<=\[).*(?=\])|\]|\["=>"")) for x in vars_temp] #get the vars defined in the model
+    # println(vars)
+    if length(expression_local) == 1
+        local locals = []
+    else
+        local cref,locals = remain_cref(expression_local[1])
+    end
+    local ctr, = remain_opt_var(model_local,expression_local[end],vars,semi_locals,locals)#modify the contraint expression, always the last argument
+    ctr = string(ctr)
+    cref = string(cref)
+    if length(expression_local) == 1
+        local constraint = "@constraint(Upper($blm),$(ctr))"
+    elseif length(expression_local) == 2
+        local constraint = "@constraint(Upper($blm),$(cref),$(ctr))"
+    end
+    local m = replace(s,p=>(pstr->"$constraint\n"*pstr))
+    local model_new = Meta.parse(m)
+    # @info("constraint ***$constraint*** added")
+    eval(model_new)
+    # println(m)
+    end
+end
+macro add_lower_cons(model,expression...)
+    model_string = string(model)
+    expression_string = [string(e) for e in expression]
+    return quote
+    local model_local = Meta.parse($model_string)
+    local expression_local = [Meta.parse(x) for x in $expression_string]
+    @assert length($expression_string) <= 2
+    @assert length($expression_string) >= 1
+    local semi_locals = Base.@locals # get the local vars within the loop
+    local model_fixed = remove_local_var(model_local,semi_locals)
+    local s = repr(eval(model_fixed))
+    local p = r"\n.*return"
+    local blm = match(r"\b.*(?==.*Bilevel)",s).match
+    local vars_temp = [split(x.match," ")[3] for x in eachmatch(r"(?<=@variable).*",s)]
+    # println(vars_temp)
+    local vars = [Meta.parse(replace(x,r"(?<=\[).*(?=\])|\]|\["=>"")) for x in vars_temp] #get the vars defined in the model
+    # println(vars)
+    if length(expression_local) == 1
+        local locals = []
+    else
+        local cref,locals = remain_cref(expression_local[1])
+    end
+    local ctr, = remain_opt_var(model_local,expression_local[end],vars,semi_locals,locals)#modify the contraint expression, always the last argument
+    ctr = string(ctr)
+    cref = string(cref)
+    if length(expression_local) == 1
+        local constraint = "@constraint(Lower($blm),$(ctr))"
+    elseif length(expression_local) == 2
+        local constraint = "@constraint(Lower($blm),$(cref),$(ctr))"
+    end
+    local m = replace(s,p=>(pstr->"$constraint\n"*pstr))
+    local model_new = Meta.parse(m)
+    # @info("constraint ***$constraint*** added")
+    eval(model_new)
+    # println(m)
+    end
+end
+function remain_opt_var(model,expression,varlist,semi_locals,local_var=[])
+    # println(expression)
+    # println(model)
+    lv = [x for x in local_var]
+    is_numeric = true
+    if expression.head == :generator
+        append!(lv,[x.args[1] for x in expression.args if x.head == :(=)])
+        append!(lv,[x.args[2].args[1] for x in expression.args if x.head == :filter])
+    end
+    if expression.head == :ref && expression.args[1] == model
+        println("success")
+        popfirst!(expression.args)#remove model name e.g mdl[:x] -> :(:x)
+        var = expression.args[1].value#remove quote :(:x) -> :x
+        @assert var in varlist
+        expression = var
+        return expression,false
+    end
+    for (k,v) in enumerate(expression.args)
+        if typeof(v) == Expr
+            expression.args[k],is_numeric_temp = remain_opt_var(model,v,varlist,semi_locals,lv)
+        else#Symbol
+            if v in lv
+                is_numeric_temp = false
+            elseif v in keys(semi_locals)
+                expression.args[k] = semi_locals[v]
+                is_numeric_temp = true
+            else
+                expression.args[k] = @eval Main $v
+                is_numeric_temp = true
+            end
+        end
+        is_numeric = is_numeric && is_numeric_temp
+    end
+    if is_numeric
+        # println(expression)
+        expression = @eval Main $expression
+    end
+    return expression,is_numeric
+end
+function remove_local_var(m::Expr,locals::Dict)
+    model = deepcopy(m)
+    @assert model.head == :ref
+    if model.args[2] in keys(locals)
+        model.args[2] = locals[model.args[2]]
+    else
+        v = model.args[2]
+        model.args[2] = @eval Main $v
+    end
+    model.args[1] = remove_local_var(model.args[1],locals)
+    return model
+end
+function remove_local_var(m::Symbol,locals::Dict)
+    return m
+end
+function remain_cref(expression)
+    local_var = []
+    if typeof(expression) == Symbol
+        return expression,local_var
+    else
+        nothing
+    end
+    @assert expression.head == :ref
+    for k in 2:length(expression.args)
+        # println(dump(expression.args[k]))
+        @assert expression.args[k].head == :kw || expression.args[k].args[1] == :in
+        if expression.args[k].head == :kw
+            v = expression.args[k].args[2]
+            expression.args[k].args[2] = @eval Main $v
+            push!(local_var,expression.args[k].args[1])
+        else
+            v = expression.args[k].args[3]
+            expression.args[k].args[3] = @eval Main $v
+            push!(local_var,expression.args[k].args[2])
+        end
+    end
+    return expression,local_var
+end

--- a/test/manipulation_test.jl
+++ b/test/manipulation_test.jl
@@ -1,0 +1,93 @@
+using Revise
+using JuMP,Gurobi,BilevelJuMP
+includet("./bilevelJuMPExtension.jl")
+# min -4sum(x) -3sum(y)
+# s.t.
+# y = argmin_y sum(y)
+#      2x + y <= 4
+#       x +2y <= 4
+#       x     >= 0
+#           y >= 0
+#
+# sol: x = 2, y = 0
+
+# opt is the orginal problem
+opt =  quote
+    function some_model()
+        blm = BilevelModel()
+        sz = 10
+        um = Upper(blm)
+        lm = Lower(blm)
+        @variable(um, x[1:sz])
+        @variable(lm, y[1:sz])
+
+        @objective(um, Min, -4sum(x) -3sum(y))
+
+        @objective(lm, Min, sum(y))
+
+        for i in 1:sz
+            @constraint(lm, 2x[i]+y[i] <= 4)
+            @constraint(lm, x[i]+2y[i] <= 4)
+            @constraint(lm, x[i] >= 0)
+            @constraint(lm, y[i] >= 0)
+        end
+        @constraint(lm,con[i in 1:sz],y[i]==1) #sign
+        return blm
+    end
+end
+
+
+# test.1 simple removal and addition of constarint named "con"
+printstyled("****REMOVAL OF CONSTRAINT CON****\n";color=:blue)
+opt = @delete_cons(opt,con)
+mdl = eval(opt)()
+optimize!(mdl,Gurobi.Optimizer())
+@assert value(mdl[:y][1]) ≈ 0
+printstyled("****ADDITION OF CONSTRAINT CON****\n";color=:blue)
+opt = @add_lower_cons(opt,con,opt[:y][1] == 1)
+mdl = eval(opt)()
+optimize!(mdl,Gurobi.Optimizer())
+@assert value(mdl[:y][1]) ≈ 1
+printstyled("****SIMPLE TEST PASSED****\n";color=:green)
+
+
+#test.2 complex removal and addition of constarint named "con" within loops
+opt = [opt,opt]
+n = 10
+@time begin
+for ii = 1:2
+    for i = 1:2
+        for j = 1:2
+            printstyled("****REMOVAL OF CONSTRAINT CON****\n";color=:blue)
+            opt[ii] = @delete_cons(opt[ii],con)
+            f = eval(opt[ii])
+            optimize!(f(),Gurobi.Optimizer(OutputFlag=0))
+            sth = [0.5,0.3]
+            idx = 2
+            printstyled("****ADDITION OF CONSTRAINT CON****\n";color=:blue)
+            opt[ii] = @add_lower_cons(opt[ii],con,sum(opt[ii][:y][i] + sth[idx]^2 for i in 1:n) == 10 + 0.1*(i+j))
+            # println(opt[ii])
+            f = eval(opt[ii])
+            optimize!(f(),Gurobi.Optimizer(OutputFlag=0))
+        end
+    end
+end
+end
+printstyled("****COMPLEX ADDITION TEST WITH LOOPS PASSED****\n";color=:green)
+
+#test.3 batch addtion of constraints
+@time begin
+    for t in 1:2
+        printstyled("****REMOVAL OF CONSTRAINT CON****\n";color=:blue)
+        opt[t] = @delete_cons(opt[t],con)
+        f = eval(opt[t])
+        optimize!(f(),Gurobi.Optimizer(OutputFlag=0))
+        sth = [1 for i in 1:n]
+        printstyled("****ADDITION OF CONSTRAINT CON****\n";color=:blue)
+        opt[t] = @add_lower_cons(opt[t],con[i = 1:n],opt[t][:y][i] == sth[i])
+        # println(opt[t])
+        f = eval(opt[t])
+        optimize!(f(),Gurobi.Optimizer(OutputFlag=0))
+    end
+end
+printstyled("****BATCH CONSTRAINTS ADDITION PASSED****\n";color=:green)


### PR DESCRIPTION
1. Three macros added in order to remove/add constraints. These operations are achieved by the following step:
**add constraints**:
step 1. Analyze the input expression (e.g. sum(model[:x][t] for t in 1:10) == 10), and replace the global/semi_local symbols/Exprs with their value. Return the "@constraint(.,.,.)" string.
step 2. Insert this string to model(code) using Regex.
**remove constraints**:
simply remove the "@constraint" string located by constraint reference using Regex
2. A comprehensive test of these macros is presented, including simple constraint removal/addition,
constraint removal/addition within for loops, and batch constraint removal/addition.