### PR TITLE
add kwarg force::Bool=false to JuMP.fix method

### DIFF
--- a/src/jump.jl
+++ b/src/jump.jl
@@ -397,12 +397,12 @@ function JuMP.delete_upper_bound(vref::BilevelVariableRef)
 end
 JuMP.is_fixed(vref::BilevelVariableRef) = variable_info(vref).has_fix
 JuMP.fix_value(vref::BilevelVariableRef) = variable_info(vref).fixed_value
-function JuMP.fix(vref::BilevelVariableRef, value)
+function JuMP.fix(vref::BilevelVariableRef, value; force::Bool=false)
     if mylevel(vref) == DUAL_OF_LOWER
         error("Dual variable cannot be fixed.")
     end
     info = variable_info(vref)
-    JuMP.fix(bound_ref(vref), value)
+    JuMP.fix(bound_ref(vref), value; force=force)
     update_variable_info(vref,
                          JuMP.VariableInfo(info.has_lb, info.lower_bound,
                                            info.has_ub, info.upper_bound,


### PR DESCRIPTION
This way the `force` option can be used with BilevelVariableRef's. See [JuMP.jl/variables.jl](https://github.com/jump-dev/JuMP.jl/blob/db80726ed15f72450afcf832eec9c89a1c1bff77/src/variables.jl#L540) for what `force` does.