### PR TITLE
JuMP.solver_name expects JuMP.Model

### DIFF
--- a/src/jump.jl
+++ b/src/jump.jl
@@ -764,7 +764,7 @@ function JuMP.show_backend_summary(io::IO, model::BilevelModel)
     if model.solver === nothing
         print(io, "No solver attached")
     else
-        print(io, "Solver name: ", solver_name(model.solver))
+        print(io, "Solver name: ", solver_name(model.upper))
     end
 end
 JuMP.object_dictionary(m::BilevelModel) = m.objdict


### PR DESCRIPTION
Not 100% sure this is how it should be implemented, but it fixed the bug for me locally. Here is JuMP.solver_name:

https://github.com/jump-dev/JuMP.jl/blob/26c327931fec98fc0f558b89e2b7ce63452c93e6/src/JuMP.jl#L336