### PR TITLE
Implementation of Iterative ProductMode()

### DIFF
--- a/src/BilevelJuMP.jl
+++ b/src/BilevelJuMP.jl
@@ -6,6 +6,7 @@ const MOIU = MathOptInterface.Utilities
 using JuMP
 using Dualization
 using LinearAlgebra
+using Printf
 
 export
 BilevelModel,

--- a/src/moi.jl
+++ b/src/moi.jl
@@ -90,11 +90,14 @@ end
 
 mutable struct ProductMode{T} <: AbstractBilevelSolverMode{T}
     epsilon::T
+    IterativeEpsilon::Vector{T}
     with_slack::Bool
+    comp_idx_in_sblm::Vector{CI}
     aggregation_group::Int # only useful in mixed mode
     function_cache::Union{Nothing, MOI.AbstractScalarFunction}
     function ProductMode(
         eps::T=zero(Float64);
+        ItEps::Vector{T}=T[],
         with_slack::Bool = false,
         aggregation_group = nothing
     ) where T<:Float64 # Real
@@ -103,7 +106,9 @@ mutable struct ProductMode{T} <: AbstractBilevelSolverMode{T}
         # positive integers point to their numbers
         return new{Float64}(
             eps,
+            ItEps,
             with_slack,
+            Vector{CI}(),
             aggregation_group === nothing ? 0 : aggregation_group,
             nothing,
             )
@@ -178,6 +183,7 @@ function reset!(mode::FortunyAmatMcCarlMode)
 end
 function reset!(mode::ProductMode)
     mode.function_cache = nothing
+    mode.comp_idx_in_sblm = Vector{CI}()
     return nothing
 end
 function reset!(mode::MixedMode)
@@ -794,6 +800,7 @@ function add_complement(mode::ProductMode{T}, m, comp::Complement,
             add_function_to_cache(mode, new_f)
         end
     end
+    appush!(mode.comp_idx_in_sblm,out_ctr)
     return out_var, out_ctr
 end
 


### PR DESCRIPTION
As discussed on discourse, an iterative solution strategy for ProductMode() would be nice. 
I have given this a first (and probably naive) shot.
Changes include: 
- added dependency Printf to format output strings in the iterative log
- added a vector of regularization parameters to ProductMode to be iteratively decreased for each solve
- added a vector of constraint references pointing to the complementarity constraints
- added an iterative solution procedure in the optimize!() function, including logging. 
I would have preferred to do the iterative procedure in place (i.e. without passing a copy for each iteration). The commented code would implement this. However, copying seems more appropriate in this case, as in place modification does not work. 
Changes are small, so no old functionality should break.

I would be happy about a brief discussion, especially in case anyone sees a more elegant approach.
Warnings/errors are not yet implemented, also not thoroughly tested on my end. This is more to test the waters and not a final approach :D 
It's my first PR, so I would be happy about some feedback!
