### PR TITLE
Consider variable bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Dualization = "191a621a-6537-11e9-281d-650236a99e60"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 Dualization = "0.5.4"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ expansions
 Note that binary expansions require variables to have upper and lower bounds.
 Also, note that the `Gurobi` solver supports products, but requires [setting the
 `"NonConvex"` options](https://github.com/jump-dev/Gurobi.jl#using-gurobi-v90-and-you-got-an-error-like-q-not-psd).
+Since, in general, constraint qualification does not hold for the lower level 
+complementary slackness conditions, they may be regularized by enforcing an inequality with a small constant. For more challenging models, an additional solution procedure is implemented, where the regularization is reduced iteratively and the NLP solver is warmstarted with primal/dual values of the previous run. For more information and some recommendations see the examples provided in the docs. 
 
 Finally, one can use `BilevelJuMP.MixedMode(default = mode)` where `mode` is one
 of the other modes described above. With this method it is possible to set

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,7 +26,8 @@ function link_example(content)
     edit_url = match(r"EditURL = \"(.+?)\"", content)[1]
     footer = match(r"^(---\n\n\*This page was generated using)"m, content)[1]
     content = replace(
-        content, footer => "!!! info\n    [View this file on Github]($(edit_url)).\n\n" * footer
+        content,
+        footer => "!!! info\n    [View this file on Github]($(edit_url)).\n\n" * footer,
     )
     return content
 end
@@ -39,12 +40,7 @@ function literate_directory(dir)
         @testset "$(filename)" begin
             _include_sandbox(filename)
         end
-        Literate.markdown(
-            filename,
-            dir;
-            documenter = true,
-            postprocess = link_example
-        )
+        Literate.markdown(filename, dir; documenter = true, postprocess = link_example)
     end
     return
 end
@@ -53,25 +49,20 @@ literate_directory(_EXAMPLE_DIR)
 
 makedocs(
     modules = [BilevelJuMP],
-    doctest  = false,
-    clean    = true,
-    format   = Documenter.HTML(
+    doctest = false,
+    clean = true,
+    format = Documenter.HTML(
         mathengine = Documenter.MathJax2(),
         prettyurls = get(ENV, "CI", nothing) == "true",
     ),
     sitename = "BilevelJuMP.jl",
-    authors  = "Joaquim Garcia",
-    pages   = [
+    authors = "Joaquim Garcia",
+    pages = [
         "Home" => "index.md",
         "Manual" => "manual.md",
-        "Examples" => [
-            joinpath("examples", f) for
-            f in readdir(_EXAMPLE_DIR) if endswith(f, ".md")
-        ]
-    ]
+        "Examples" =>
+            [joinpath("examples", f) for f in readdir(_EXAMPLE_DIR) if endswith(f, ".md")],
+    ],
 )
 
-deploydocs(
-    repo = "github.com/joaquimg/BilevelJuMP.jl.git",
-    push_preview = true,
-)
+deploydocs(repo = "github.com/joaquimg/BilevelJuMP.jl.git", push_preview = true)

--- a/docs/src/examples/DTMP_example1.jl
+++ b/docs/src/examples/DTMP_example1.jl
@@ -56,11 +56,11 @@ model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-9))
 @objective(Lower(model), Min, -x - y + w)
 
 # Lower constraints
-@constraint(Lower(model),  y >= 0)
+@constraint(Lower(model), y >= 0)
 @constraint(Lower(model), x + y + w <= 8)
-@constraint(Lower(model),  x >= 0)
-@constraint(Lower(model),  x <= 4)
-@constraint(Lower(model),  w == 1)
+@constraint(Lower(model), x >= 0)
+@constraint(Lower(model), x <= 4)
+@constraint(Lower(model), w == 1)
 
 # Initial Starting conditions  #src
 
@@ -69,7 +69,7 @@ model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-9))
 optimize!(model)
 
 # Auto testing
-@test value(x) ≈ 1 atol=1e-2
-@test value(y) ≈ 6 atol=1e-2
-@test value(z) ≈ 1 atol=1e-2
-@test value(w) ≈ 1 atol=1e-2
+@test value(x) ≈ 1 atol = 1e-2
+@test value(y) ≈ 6 atol = 1e-2
+@test value(z) ≈ 1 atol = 1e-2
+@test value(w) ≈ 1 atol = 1e-2

--- a/docs/src/examples/FOBP_example2.2.jl
+++ b/docs/src/examples/FOBP_example2.2.jl
@@ -52,9 +52,9 @@ model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-9))
 @objective(Lower(model), Min, -x)
 
 #-
-@constraint(Lower(model), x +  y <= 8)
-@constraint(Lower(model), 4x +  y >= 8)
-@constraint(Lower(model), 2x +  y <= 13)
+@constraint(Lower(model), x + y <= 8)
+@constraint(Lower(model), 4x + y >= 8)
+@constraint(Lower(model), 2x + y <= 13)
 @constraint(Lower(model), 2x - 7y <= 0)
 @constraint(Lower(model), x <= 5)
 
@@ -63,9 +63,9 @@ model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-9))
 
 optimize!(model)
 
-@test objective_value(model) ≈ 3 * (3.5 * 8 / 15) + (8 / 15) atol=1e-3
-@test value(x) ≈ 3.5 * 8 / 15 atol=1e-6
-@test value(y) ≈ 8 / 15 atol=1e-6
+@test objective_value(model) ≈ 3 * (3.5 * 8 / 15) + (8 / 15) atol = 1e-3
+@test value(x) ≈ 3.5 * 8 / 15 atol = 1e-6
+@test value(y) ≈ 8 / 15 atol = 1e-6
 
 # TODO: why are these commented out?    #src
 # @test dual(l2) #≈ [0] atol=atol       #src

--- a/docs/src/examples/FOBP_example2.jl
+++ b/docs/src/examples/FOBP_example2.jl
@@ -53,9 +53,9 @@ end)
 @objective(Lower(model), Min, -x)
 
 # Lower level constraints
-@constraint(Lower(model), l1,  x +  y <= 8)
-@constraint(Lower(model), l2, 4x +  y >= 8)
-@constraint(Lower(model), l3, 2x +  y <= 13)
+@constraint(Lower(model), l1, x + y <= 8)
+@constraint(Lower(model), l2, 4x + y >= 8)
+@constraint(Lower(model), l3, 2x + y <= 13)
 @constraint(Lower(model), l4, 2x - 7y <= 0)
 
 # !!! tip
@@ -86,15 +86,15 @@ optimize!(model)
 
 # Automated testing
 
-@test objective_value(model) ≈ 3 * (3.5 * 8 / 15) + (8 / 15) atol=1e-4
-@test BilevelJuMP.lower_objective_value(model) ≈ -3.5 * 8 / 15 atol=1e-4
-@test objective_value(Lower(model)) ≈ -3.5 * 8 / 15 atol=1e-4
-@test value(x) ≈ 3.5 * 8 / 15 atol=1e-4
-@test value(y) ≈ 8 / 15 atol=1e-4
-@test value(u1) ≈ 3.5 * 8 / 15 atol=1e-4
-@test value(l1) ≈ 4.5 * 8 / 15 atol=1e-4
-@test dual(l1) ≈ [0] atol=1e-4
-@test dual(l3) ≈ [0] atol=1e-4
+@test objective_value(model) ≈ 3 * (3.5 * 8 / 15) + (8 / 15) atol = 1e-4
+@test BilevelJuMP.lower_objective_value(model) ≈ -3.5 * 8 / 15 atol = 1e-4
+@test objective_value(Lower(model)) ≈ -3.5 * 8 / 15 atol = 1e-4
+@test value(x) ≈ 3.5 * 8 / 15 atol = 1e-4
+@test value(y) ≈ 8 / 15 atol = 1e-4
+@test value(u1) ≈ 3.5 * 8 / 15 atol = 1e-4
+@test value(l1) ≈ 4.5 * 8 / 15 atol = 1e-4
+@test dual(l1) ≈ [0] atol = 1e-4
+@test dual(l3) ≈ [0] atol = 1e-4
 
 # TODO: why are these commented out?    #src
 # @test dual(l2) #≈ [0] atol=atol       #src

--- a/docs/src/examples/FOBP_example3.jl
+++ b/docs/src/examples/FOBP_example3.jl
@@ -42,46 +42,50 @@ model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-9))
 # Global variables
 
 I = 7 # maximum literals
-clauses = [[1,2,3],[-1,-4,3],[7,-6,4],[5,6,7]]
+clauses = [[1, 2, 3], [-1, -4, 3], [7, -6, 4], [5, 6, 7]]
 atol = 1e-6
 # First we need to create all of the variables in the upper and lower problems:
 
 # Upper level variables
-@variable(Upper(model), ya[i=1:I])
-@variable(Upper(model), yb[i=1:I])
+@variable(Upper(model), ya[i = 1:I])
+@variable(Upper(model), yb[i = 1:I])
 @variable(Upper(model), z)
 
 
 #Lower level variables
-@variable(Lower(model), x[i=1:I])
+@variable(Lower(model), x[i = 1:I])
 
 # Then we can add the objective and constraints of the upper problem:
 
 # Upper level objecive function
-@objective(Upper(model), Min, sum(x[i] for i in 1:I) - z)
+@objective(Upper(model), Min, sum(x[i] for i = 1:I) - z)
 
 # Upper level constraints
 @constraint(Upper(model), ca, z <= 1)
 @constraint(Upper(model), cb, z >= 0)
-@constraint(Upper(model), c1[i=1:I], ya[i] >= 0)
-@constraint(Upper(model), c2[i=1:I], ya[i] <= 1)
-@constraint(Upper(model), c3[i=1:I], yb[i] >= 0)
-@constraint(Upper(model), c4[i=1:I], yb[i] <= 1)
-@constraint(Upper(model), c5[i=1:I], ya[i] + yb[i] == 1)
+@constraint(Upper(model), c1[i = 1:I], ya[i] >= 0)
+@constraint(Upper(model), c2[i = 1:I], ya[i] <= 1)
+@constraint(Upper(model), c3[i = 1:I], yb[i] >= 0)
+@constraint(Upper(model), c4[i = 1:I], yb[i] <= 1)
+@constraint(Upper(model), c5[i = 1:I], ya[i] + yb[i] == 1)
 
 # for c in clauses
-@constraint(Upper(model), cc[k in eachindex(clauses)], sum(i > 0 ? ya[i] : yb[-i] for i in clauses[k]) >= z)
+@constraint(
+    Upper(model),
+    cc[k in eachindex(clauses)],
+    sum(i > 0 ? ya[i] : yb[-i] for i in clauses[k]) >= z
+)
 
 
 # Followed by the objective and constraints of the lower problem:
 
 # Lower objective function
-@objective(Lower(model), Min, -sum(x[i] for i in 1:I))
+@objective(Lower(model), Min, -sum(x[i] for i = 1:I))
 
 # Lower constraints
-@constraint(Lower(model), b1[i=1:I], x[i] >= 0)
-@constraint(Lower(model), b2[i=1:I], x[i] <= ya[i])
-@constraint(Lower(model), b3[i=1:I], x[i] <= yb[i])
+@constraint(Lower(model), b1[i = 1:I], x[i] >= 0)
+@constraint(Lower(model), b2[i = 1:I], x[i] <= ya[i])
+@constraint(Lower(model), b3[i = 1:I], x[i] <= yb[i])
 
 
 # Initial Starting conditions
@@ -90,7 +94,7 @@ JuMP.set_start_value.(x, 0)
 JuMP.set_start_value.(ya, 1)
 JuMP.set_start_value.(yb, 0)
 JuMP.set_start_value(z, 1)
-for i in 1:I
+for i = 1:I
     JuMP.set_dual_start_value.(b1, 0)
     JuMP.set_dual_start_value.(b2, 0)
     JuMP.set_dual_start_value.(b3, -1)
@@ -106,12 +110,11 @@ primal_status(model)
 termination_status(model)
 
 # Auto testing
-@test objective_value(model) ≈ -1 atol=atol
-@test value.(x) ≈ zeros(I) atol=atol
-@test value.(ya) ≈ ones(I) atol=atol
-@test value.(yb) ≈ zeros(I) atol=atol
-@test value(z) ≈ 1 atol=atol
+@test objective_value(model) ≈ -1 atol = atol
+@test value.(x) ≈ zeros(I) atol = atol
+@test value.(ya) ≈ ones(I) atol = atol
+@test value.(yb) ≈ zeros(I) atol = atol
+@test value(z) ≈ 1 atol = atol
 # @show dual.(b1) #≈ 6 atol=atol
 # @show dual.(b2) #≈ 2 atol=atol
 # @show dual.(b3) #≈ 2 atol=atol
-

--- a/docs/src/examples/FOBP_example4.jl
+++ b/docs/src/examples/FOBP_example4.jl
@@ -41,7 +41,7 @@ atol = 1e-3
 @objective(Upper(model), Min, x^2 + y)
 
 # Upper level constraints
-@constraint(Upper(model), u1, -x -y <= 0)
+@constraint(Upper(model), u1, -x - y <= 0)
 
 # Followed by the objective and constraints of the lower problem:
 
@@ -61,7 +61,6 @@ primal_status(model)
 termination_status(model)
 
 # Auto testing
-@test objective_value(model) ≈ 0 atol=atol
-@test value(x) ≈ 0 atol=atol
-@test value(y) ≈ 0 atol=atol
-
+@test objective_value(model) ≈ 0 atol = atol
+@test value(x) ≈ 0 atol = atol
+@test value(y) ≈ 0 atol = atol

--- a/docs/src/examples/Iterative_example1.jl
+++ b/docs/src/examples/Iterative_example1.jl
@@ -93,9 +93,11 @@ optimize!(model)
 # The following script illustrates how one can verify the desired behavior; the math remains unchanged from above...
 # This time, we do not suppress any solver output. You can see that IterEps only contains one value (and it is the same as the regularization specified for the initial solve).
 # If all options for the warmstart are set correctly, you should see that the solver (in our case Ipopt) accepts the warmstart solution as optimal. 
-# Primal and dual infeasibility of the initial point (inf_pr/inf_du) should be very low (i.e. within solver specified tolerances for optimal termination). 
-# In our example, both should be less than 1e-9. 
-# This is an important check to run before your true task, 
+# For more complicated problems, it may be necessary to relax this statement to near optimal. However, very few iterations should be made to find the optimal solution again.
+# Primal and dual infeasibility of the initial point (inf_pr/inf_du) should in general be very low (i.e. in the order of solver specified tolerances for optimal termination). 
+# In our simple example, both should be less than 1e-9. 
+# Depending on the actual problem and modifications by Ipopt (such as scaling etc.), this may not always be the case and you could come across values of roughly 1e-6 sometimes...
+# In general, you should always check that provided warmstarts actually work as desired before going ahead!
 # It is left to the user to verify that using an empty IterAttr does not yield the same bahavior. 
 
 using JuMP, BilevelJuMP, Ipopt

--- a/docs/src/examples/Iterative_example1.jl
+++ b/docs/src/examples/Iterative_example1.jl
@@ -28,31 +28,34 @@ using JuMP, BilevelJuMP, Ipopt
 # First, we need to specify an iterable with our desired regularization values.
 # The problem will be solved for each element in this series, while the next step starts at the optimal values of the previous iteration. 
 # Note, that this iterable specifies regularization parameters after a first solve with the initial value (later set to 1e-0). 
-IterEps = [1e-0 * 0.99^i for i in 1:1500]
+iter_eps = [1e-0 * 0.99^i for i = 1:1500]
 
 # Also, it is possible to give specific solver attributes that are not valid for the initial solve, but only subsequent ones.
 # Warmstarting interior point algorithms is difficult, but some of the following options can be recommended for Ipopt. 
 # Allowing warmstarts explicitly is necessary in Ipopt, this may vary with different solvers.
 # In addition, we are suppressing solver outputs for all but the first iteration (and could instead write a log to a file using the commented lines).
 
-IterAttr = Dict( 
-    "mu_init" => 1e-9, 
-    "warm_start_init_point"=> "yes", 
-    "warm_start_bound_push"=> 1e-12, 
-    "warm_start_bound_frac"=> 1e-12, 
-    "warm_start_slack_bound_frac"=> 1e-12, 
-    "warm_start_slack_bound_push"=> 1e-12, 
-    "warm_start_mult_bound_push" => 1e-12, 
+iter_attr = Dict(
+    "mu_init" => 1e-9,
+    "warm_start_init_point" => "yes",
+    "warm_start_bound_push" => 1e-12,
+    "warm_start_bound_frac" => 1e-12,
+    "warm_start_slack_bound_frac" => 1e-12,
+    "warm_start_slack_bound_push" => 1e-12,
+    "warm_start_mult_bound_push" => 1e-12,
     # "output_file" => "solver.log",
     # "file_print_level" => 8,
     "print_level" => 0,
-    )
+)
 # Note that for other solvers, these options may differ. 
 # You can also specify other options here. 
 # For example, you could play around with an adaptive mu strategy in the initial solve and a monotone mu strategy in subsequent iterations (see the Ipopt options docs). 
 
 # We can now specify our model, where the initial regularization is 1e+0, followed by setting the iterative values and settings:
-model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEps=IterEps, IterAttr = IterAttr))
+model = BilevelModel(
+    Ipopt.Optimizer,
+    mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+)
 
 # The following lines are copied from the example as presented before: 
 @variable(Upper(model), x)
@@ -63,55 +66,58 @@ model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEp
 @constraint(Upper(model), y + 2x + z <= 9)
 @constraint(Upper(model), z == 1)
 @objective(Lower(model), Min, -x - y + w)
-@constraint(Lower(model),  y >= 0)
+@constraint(Lower(model), y >= 0)
 @constraint(Lower(model), x + y + w <= 8)
-@constraint(Lower(model),  x >= 0)
-@constraint(Lower(model),  x <= 4)
-@constraint(Lower(model),  w == 1)
+@constraint(Lower(model), x >= 0)
+@constraint(Lower(model), x <= 4)
+@constraint(Lower(model), w == 1)
 
 # Setting the right solver options for NLPs can make a huge difference. It is recommended to play around with these when solving challenging models.
 # All options set with set_optimizer_attribute() carry over to subsequent iterations. 
-# In case you want to return to default settings for following solves, you have to manually specify these in the IterAttr options again. 
-# For the initial solution, we want to solve with a target mu of 1e-9 (see the Ipopt docs for an explanation), which is the initial mu as set in IterAttr. 
+# In case you want to return to default settings for following solves, you have to manually specify these in the iter_attr options again. 
+# For the initial solution, we want to solve with a target mu of 1e-9 (see the Ipopt docs for an explanation), which is the initial mu as set in iter_attr. 
 # Other options can easily be set the same way. 
 set_optimizer_attribute(model, "mu_target", 1e-9)
 
 # Warmstarting the first iteration is also possible, start values need to be provided using set_start_value() and set_dual_start_value() functions, or in the variable declarations.
-# Note, that if you are using starting values, the solver options must be set accordingly for the first iteration (as with mu_target, not via IterAttr...).
+# Note, that if you are using starting values, the solver options must be set accordingly for the first iteration (as with mu_target, not via iter_attr...).
 
 # Finally, we can optimize: 
 optimize!(model)
 
 # Auto testing
-@test value(x) ≈ 1 atol=1e-4
-@test value(y) ≈ 6 atol=1e-4
-@test value(z) ≈ 1 atol=1e-4
-@test value(w) ≈ 1 atol=1e-4
+@test value(x) ≈ 1 atol = 1e-4
+@test value(y) ≈ 6 atol = 1e-4
+@test value(z) ≈ 1 atol = 1e-4
+@test value(w) ≈ 1 atol = 1e-4
 
 
 # It is important to check that the solver actually accepts and uses our warmstart as desired. Otherwise, the iterative solution procedure does not work at all!
 # The following script illustrates how one can verify the desired behavior; the math remains unchanged from above...
-# This time, we do not suppress any solver output. You can see that IterEps only contains one value (and it is the same as the regularization specified for the initial solve).
+# This time, we do not suppress any solver output. You can see that iter_eps only contains one value (and it is the same as the regularization specified for the initial solve).
 # If all options for the warmstart are set correctly, you should see that the solver (in our case Ipopt) accepts the warmstart solution as optimal. 
 # For more complicated problems, it may be necessary to relax this statement to near optimal. However, very few iterations should be made to find the optimal solution again.
 # Primal and dual infeasibility of the initial point (inf_pr/inf_du) should in general be very low (i.e. in the order of solver specified tolerances for optimal termination). 
 # In our simple example, both should be less than 1e-9. 
 # Depending on the actual problem and modifications by Ipopt (such as scaling etc.), this may not always be the case and you could come across values of roughly 1e-6 sometimes...
 # In general, you should always check that provided warmstarts actually work as desired before going ahead!
-# It is left to the user to verify that using an empty IterAttr does not yield the same bahavior. 
+# It is left to the user to verify that using an empty iter_attr does not yield the same bahavior. 
 
 using JuMP, BilevelJuMP, Ipopt
-IterEps = [1e-0 for i in 1:1]
-IterAttr = Dict( 
-    "mu_init" => 1e-9, 
-    "warm_start_init_point"=> "yes", 
-    "warm_start_bound_push"=> 1e-12, 
-    "warm_start_bound_frac"=> 1e-12, 
-    "warm_start_slack_bound_frac"=> 1e-12, 
-    "warm_start_slack_bound_push"=> 1e-12, 
-    "warm_start_mult_bound_push" => 1e-12, 
-    )
-TestModel = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEps=IterEps, IterAttr = IterAttr))
+iter_eps = [1e-0 for i = 1:1]
+iter_attr = Dict(
+    "mu_init" => 1e-9,
+    "warm_start_init_point" => "yes",
+    "warm_start_bound_push" => 1e-12,
+    "warm_start_bound_frac" => 1e-12,
+    "warm_start_slack_bound_frac" => 1e-12,
+    "warm_start_slack_bound_push" => 1e-12,
+    "warm_start_mult_bound_push" => 1e-12,
+)
+TestModel = BilevelModel(
+    Ipopt.Optimizer,
+    mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+)
 @variable(Upper(TestModel), x)
 @variable(UpperOnly(TestModel), z)
 @variable(Lower(TestModel), y)
@@ -120,10 +126,10 @@ TestModel = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;It
 @constraint(Upper(TestModel), y + 2x + z <= 9)
 @constraint(Upper(TestModel), z == 1)
 @objective(Lower(TestModel), Min, -x - y + w)
-@constraint(Lower(TestModel),  y >= 0)
+@constraint(Lower(TestModel), y >= 0)
 @constraint(Lower(TestModel), x + y + w <= 8)
-@constraint(Lower(TestModel),  x >= 0)
-@constraint(Lower(TestModel),  x <= 4)
-@constraint(Lower(TestModel),  w == 1)
+@constraint(Lower(TestModel), x >= 0)
+@constraint(Lower(TestModel), x <= 4)
+@constraint(Lower(TestModel), w == 1)
 set_optimizer_attribute(TestModel, "mu_target", 1e-9)
 optimize!(TestModel)

--- a/docs/src/examples/Iterative_example1.jl
+++ b/docs/src/examples/Iterative_example1.jl
@@ -1,0 +1,89 @@
+# # Example 1 on Iterative Solution for ProductMode
+# This example is again from the book Decomposition Techniques in Mathematical Programming
+# Chapter 7.2, page 281, [url](https://www.springer.com/gp/book/9783540276852)
+# The formulation is the same as used before, but we are now focussing on more practical aspects of an iterative product mode.
+# In particular, a few tricks for solving iteratively with Ipopt are provided. 
+
+# Model of the problem
+# First level
+# ```math
+# \min -x + 4y + z,\\
+# \notag s.t.\\
+# y + 2x + z \leq 9,\\
+# z = 1,\\
+# ```
+# Second level
+# ```math
+# \min -x - y + w,\\
+# \notag s.t.\\
+# y \geq 0,\\
+# x + y + w \leq 8,\\
+# x \geq 0,\\
+# x \leq 4,\\
+# x = 1.\\
+# ```
+
+using JuMP, BilevelJuMP, Ipopt
+
+# First, we need to specify an iterable with our desired regularization values.
+# The problem will be solved for each element in this series, while the next step starts at the optimal values of the previous iteration. 
+# Note, that this iterable specifies regularization parameters after a first solve with the initial value 1e-0. 
+IterEps = [1e-0 * 0.99^i for i in 1:1500]
+
+# Also, it is possible to give specific solver attributes that are not valid for the initial solve, but only subsequent ones.
+# Warmstarting interior point algorithms is difficult, but some of the following options can be recommended. 
+# Allowing warmstarts in Ipopt explicitly is necessary in Ipopt, this may vary with different solvers.
+# Also, we are suppressing solver outputs for all but the first iteration (and could instead write a log to a file using the commented lines).
+
+IterAttr = Dict( 
+    "mu_init" => 1e-9, 
+    "warm_start_init_point"=> "yes", 
+    "warm_start_bound_push"=> 1e-12, 
+    "warm_start_bound_frac"=> 1e-12, 
+    "warm_start_slack_bound_frac"=> 1e-12, 
+    "warm_start_slack_bound_push"=> 1e-12, 
+    "warm_start_mult_bound_push" => 1e-12, 
+    # "output_file" => "solver.log",
+    # "file_print_level" => 8,
+    "print_level" => 0,
+    )
+# Note that for other solvers, these options may differ. 
+# You can also specify other options here. 
+# For example, you could play around with an adaptive mu strategy in the initial solve and a monotone mu strategy in subsequent iterations (see the Ipopt options docs). 
+
+# We can now specify our model, where the initial regularization is 1e+0, followed by setting the iterative values and settings:
+model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEps=IterEps, IterAttr = IterAttr))
+
+# The following lines are copied from the example as presented before: 
+@variable(Upper(model), x)
+@variable(UpperOnly(model), z)
+@variable(Lower(model), y)
+@variable(LowerOnly(model), w)
+@objective(Upper(model), Min, -x + 4y + z)
+@constraint(Upper(model), y + 2x + z <= 9)
+@constraint(Upper(model), z == 1)
+@objective(Lower(model), Min, -x - y + w)
+@constraint(Lower(model),  y >= 0)
+@constraint(Lower(model), x + y + w <= 8)
+@constraint(Lower(model),  x >= 0)
+@constraint(Lower(model),  x <= 4)
+@constraint(Lower(model),  w == 1)
+
+# Setting the right solver options for NLPs can make a huge difference. It is recommended to play around with these when solving challenging models.
+# All options set with set_optimizer_attribute() carry over to subsequent iterations. 
+# In case you want to return to default settings for following solves, you have to manually specify these in the IterAttr options again. 
+# For the initial solution, we want to solve with a target mu of 1e-9 (see the Ipopt docs for an explanation), which is the initial mu as set in IterAttr. 
+# Other options can easily be set the same way. 
+set_optimizer_attribute(model, "mu_target", 1e-9)
+
+# Warmstarting the first iteration is also possible, start values need to be provided using set_start_value() and set_dual_start_value() functions, or in the variable declarations.
+# Note, that if you are using starting values, the solver options must be set accordingly for the first iteration (as above...).
+
+# Finally, we can optimize: 
+optimize!(model)
+
+# Auto testing
+@test value(x) ≈ 1 atol=1e-4
+@test value(y) ≈ 6 atol=1e-4
+@test value(z) ≈ 1 atol=1e-4
+@test value(w) ≈ 1 atol=1e-4

--- a/docs/src/examples/Iterative_example2.jl
+++ b/docs/src/examples/Iterative_example2.jl
@@ -1,0 +1,158 @@
+# # Example 2 on Iterative Solution for ProductMode
+# This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
+# It can be found in section 3 "Numerical Examples"
+
+# The leader solves the following first level
+# ```math
+# \max_{Q \geq 0} (a-b(q_1 + q_2 + Q))Q + CQ,\\
+# ```
+# Firm i = 1,2 solves the following lower-level problem where it takes the upper-level quantity Q as fixed and tries to maximize profits while in Nash-Cournot competition with the other Stackelberg follower firm j.
+# ```math
+# \max_{q_i \geq 0} (a-b(q_i + q_j + Q))q_i + c_i q_i,\\
+# ```
+# Subsequently, we will combine the two lower level players' problem into a single one with equivalent KKTs. 
+
+using JuMP, BilevelJuMP, Ipopt
+
+F = [1,2]
+c = Dict(1=>1, 2=>1)
+C = 1
+a = 13
+b = 1
+
+# First, we need to specify an iterable with our desired regularization values.
+# The problem will be solved for each element in this series, while the next step starts at the optimal values of the previous iteration. 
+# Note, that this iterable specifies regularization parameters after a first solve with the initial value 1e-0. 
+IterEps = [1e-0 * 0.99^i for i in 1:1500]
+
+# Also, it is possible to give specific solver attributes that are not valid for the initial solve, but only subsequent ones.
+# Warmstarting interior point algorithms is difficult, but some of the following options can be recommended. 
+# Allowing warmstarts in Ipopt explicitly is necessary in Ipopt, this may vary with different solvers.
+# Also, we are suppressing solver outputs for all but the first iteration (and could instead write a log to a file using the commented lines).
+
+IterAttr = Dict( 
+    "mu_init" => 1e-9, 
+    "warm_start_init_point"=> "yes", 
+    "warm_start_bound_push"=> 1e-12, 
+    "warm_start_bound_frac"=> 1e-12, 
+    "warm_start_slack_bound_frac"=> 1e-12, 
+    "warm_start_slack_bound_push"=> 1e-12, 
+    "warm_start_mult_bound_push" => 1e-12, 
+    # "output_file" => "solver.log",
+    # "file_print_level" => 8,
+    "print_level" => 0,
+    )
+# Note that for other solvers, these options may differ. 
+# You can also specify other options here. 
+# For example, you could play around with an adaptive mu strategy in the initial solve and a monotone mu strategy in subsequent iterations (see the Ipopt options docs). 
+
+# We can now specify our model, where the initial regularization is 1e+0, followed by setting the iterative values and settings:
+model1 = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEps=IterEps, IterAttr = IterAttr))
+
+# The following lines are copied from the example as presented before: 
+@variable(Lower(model1), q[F] >= 0)
+@variable(Upper(model1), Q >= 0)
+
+@objective(Upper(model1), Max, ((a-b * (q[1] + q[2] + Q)) * Q - C*Q) )
+
+@objective(Lower(model1), Min, -((a-b * (q[1] + q[2] + Q)) * q[1] - C*q[1] + (a-b * (q[1] + q[2] + Q)) * q[2] - C*q[2] + b*q[1]*q[2]) )
+
+# Setting the right solver options for NLPs can make a huge difference. It is recommended to play around with these when solving challenging models.
+# All options set with set_optimizer_attribute() carry over to subsequent iterations. 
+# In case you want to return to default settings for following solves, you have to manually specify these in the IterAttr options again. 
+# For the initial solution, we want to solve with a target mu of 1e-9 (see the Ipopt docs for an explanation), which is the initial mu as set in IterAttr. 
+# Other options can easily be set the same way. 
+set_optimizer_attribute(model1, "mu_target", 1e-9)
+
+# Warmstarting the first iteration is also possible, start values need to be provided using set_start_value() and set_dual_start_value() functions, or in the variable declarations.
+# Note, that if you are using starting values, the solver options must be set accordingly for the first iteration (as above...).
+
+# Finally, we can optimize: 
+optimize!(model1)
+
+# To verify that the KKTs are correctly set, we could also print the model to an lp file: 
+# optimize!(model1, bilevel_prob = "blp.lp")
+
+# Auto testing
+
+@test isapprox(value(model1[:Q]), 6; atol=1e-6)
+@test isapprox(value.(model1[:q]).data, [2,2]; atol=1e-6) 
+
+#######################
+# The following lines show the other two datasets provided in the original paper. 
+# Dataset 2: 
+F = [1,2]
+c = Dict(1=>1, 2=>1)
+C = 1
+a = 13
+b = 0.1
+
+IterEps = [1e-0 * 0.99^i for i in 1:1500]
+
+IterAttr = Dict( 
+    "mu_init" => 1e-9, 
+    "warm_start_init_point"=> "yes", 
+    "warm_start_bound_push"=> 1e-12, 
+    "warm_start_bound_frac"=> 1e-12, 
+    "warm_start_slack_bound_frac"=> 1e-12, 
+    "warm_start_slack_bound_push"=> 1e-12, 
+    "warm_start_mult_bound_push" => 1e-12, 
+    "print_level" => 0,
+    )
+
+model2 = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEps=IterEps, IterAttr = IterAttr))
+
+@variable(Lower(model2), q[F] >= 0)
+@variable(Upper(model2), Q >= 0)
+
+@objective(Upper(model2), Max, ((a-b * (q[1] + q[2] + Q)) * Q - C*Q) )
+
+@objective(Lower(model2), Min, -((a-b * (q[1] + q[2] + Q)) * q[1] - C*q[1] + (a-b * (q[1] + q[2] + Q)) * q[2] - C*q[2] + b*q[1]*q[2]) )
+
+set_optimizer_attribute(model2, "mu_target", 1e-9)
+
+optimize!(model2)
+
+# Auto testing
+
+@test isapprox(value(model2[:Q]), 60; atol=1e-6)
+@test isapprox(value.(model2[:q]).data, [20,20]; atol=1e-6) 
+
+#######################
+# Dataset 3: 
+F = [1,2]
+c = Dict(1=>1, 2=>1)
+C = 2
+a = 13
+b = 0.1
+
+IterEps = [1e-0 * 0.99^i for i in 1:1500]
+
+IterAttr = Dict( 
+    "mu_init" => 1e-9, 
+    "warm_start_init_point"=> "yes", 
+    "warm_start_bound_push"=> 1e-12, 
+    "warm_start_bound_frac"=> 1e-12, 
+    "warm_start_slack_bound_frac"=> 1e-12, 
+    "warm_start_slack_bound_push"=> 1e-12, 
+    "warm_start_mult_bound_push" => 1e-12, 
+    "print_level" => 0,
+    )
+
+model3 = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEps=IterEps, IterAttr = IterAttr))
+
+@variable(Lower(model3), q[F] >= 0)
+@variable(Upper(model3), Q >= 0)
+
+@objective(Upper(model3), Max, ((a-b * (q[1] + q[2] + Q)) * Q - C*Q) )
+
+@objective(Lower(model3), Min, -((a-b * (q[1] + q[2] + Q)) * q[1] - C*q[1] + (a-b * (q[1] + q[2] + Q)) * q[2] - C*q[2] + b*q[1]*q[2]) )
+
+set_optimizer_attribute(model3, "mu_target", 1e-9)
+
+optimize!(model3)
+
+# Auto testing
+
+@test isapprox(value(model3[:Q]), 55; atol=1e-6)
+@test isapprox(value.(model3[:q]).data, [18.333,18.333]; atol=1e-2) 

--- a/docs/src/examples/Iterative_example2.jl
+++ b/docs/src/examples/Iterative_example2.jl
@@ -14,8 +14,8 @@
 
 using JuMP, BilevelJuMP, Ipopt
 
-F = [1,2]
-c = Dict(1=>1, 2=>1)
+F = [1, 2]
+c = Dict(1 => 1, 2 => 1)
 C = 1
 a = 13
 b = 1
@@ -23,44 +23,54 @@ b = 1
 # First, we need to specify an iterable with our desired regularization values.
 # The problem will be solved for each element in this series, while the next step starts at the optimal values of the previous iteration. 
 # Note, that this iterable specifies regularization parameters after a first solve with the initial value 1e-0. 
-IterEps = [1e-0 * 0.99^i for i in 1:1500]
+iter_eps = [1e-0 * 0.99^i for i = 1:1500]
 
 # Also, it is possible to give specific solver attributes that are not valid for the initial solve, but only subsequent ones.
 # Warmstarting interior point algorithms is difficult, but some of the following options can be recommended. 
 # Allowing warmstarts in Ipopt explicitly is necessary in Ipopt, this may vary with different solvers.
 # Also, we are suppressing solver outputs for all but the first iteration (and could instead write a log to a file using the commented lines).
 
-IterAttr = Dict( 
-    "mu_init" => 1e-9, 
-    "warm_start_init_point"=> "yes", 
-    "warm_start_bound_push"=> 1e-12, 
-    "warm_start_bound_frac"=> 1e-12, 
-    "warm_start_slack_bound_frac"=> 1e-12, 
-    "warm_start_slack_bound_push"=> 1e-12, 
-    "warm_start_mult_bound_push" => 1e-12, 
+iter_attr = Dict(
+    "mu_init" => 1e-9,
+    "warm_start_init_point" => "yes",
+    "warm_start_bound_push" => 1e-12,
+    "warm_start_bound_frac" => 1e-12,
+    "warm_start_slack_bound_frac" => 1e-12,
+    "warm_start_slack_bound_push" => 1e-12,
+    "warm_start_mult_bound_push" => 1e-12,
     # "output_file" => "solver.log",
     # "file_print_level" => 8,
     "print_level" => 0,
-    )
+)
 # Note that for other solvers, these options may differ. 
 # You can also specify other options here. 
 # For example, you could play around with an adaptive mu strategy in the initial solve and a monotone mu strategy in subsequent iterations (see the Ipopt options docs). 
 
 # We can now specify our model, where the initial regularization is 1e+0, followed by setting the iterative values and settings:
-model1 = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEps=IterEps, IterAttr = IterAttr))
+model1 = BilevelModel(
+    Ipopt.Optimizer,
+    mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+)
 
 # The following lines merge the two lower level problems into a single one. It is left to the reader to check the KKTs are indeed equivalent: 
 @variable(Lower(model1), q[F] >= 0)
 @variable(Upper(model1), Q >= 0)
 
-@objective(Upper(model1), Max, ((a-b * (q[1] + q[2] + Q)) * Q - C*Q) )
+@objective(Upper(model1), Max, ((a - b * (q[1] + q[2] + Q)) * Q - C * Q))
 
-@objective(Lower(model1), Min, -((a-b * (q[1] + q[2] + Q)) * q[1] - C*q[1] + (a-b * (q[1] + q[2] + Q)) * q[2] - C*q[2] + b*q[1]*q[2]) )
+@objective(
+    Lower(model1),
+    Min,
+    -(
+        (a - b * (q[1] + q[2] + Q)) * q[1] - C * q[1] + (a - b * (q[1] + q[2] + Q)) * q[2] -
+        C * q[2] + b * q[1] * q[2]
+    )
+)
 
 # Setting the right solver options for NLPs can make a huge difference. It is recommended to play around with these when solving challenging models.
 # All options set with set_optimizer_attribute() carry over to subsequent iterations. 
-# In case you want to return to default settings for following solves, you have to manually specify these in the IterAttr options again. 
-# For the initial solution, we want to solve with a target mu of 1e-9 (see the Ipopt docs for an explanation), which is the initial mu as set in IterAttr. 
+# In case you want to return to default settings for following solves, you have to manually specify these in the iter_attr options again. 
+# For the initial solution, we want to solve with a target mu of 1e-9 (see the Ipopt docs for an explanation), which is the initial mu as set in iter_attr. 
 # Other options can easily be set the same way. 
 set_optimizer_attribute(model1, "mu_target", 1e-9)
 
@@ -75,39 +85,49 @@ optimize!(model1)
 
 # Auto testing
 
-@test isapprox(value(model1[:Q]), 6; atol=1e-6)
-@test isapprox(value.(model1[:q]).data, [2,2]; atol=1e-6) 
+@test isapprox(value(model1[:Q]), 6; atol = 1e-6)
+@test isapprox(value.(model1[:q]).data, [2, 2]; atol = 1e-6)
 
 #######################
 # The following lines show the other two datasets provided in the original paper. 
 # Dataset 2: 
-F = [1,2]
-c = Dict(1=>1, 2=>1)
+F = [1, 2]
+c = Dict(1 => 1, 2 => 1)
 C = 1
 a = 13
 b = 0.1
 
-IterEps = [1e-0 * 0.99^i for i in 1:1500]
+iter_eps = [1e-0 * 0.99^i for i = 1:1500]
 
-IterAttr = Dict( 
-    "mu_init" => 1e-9, 
-    "warm_start_init_point"=> "yes", 
-    "warm_start_bound_push"=> 1e-12, 
-    "warm_start_bound_frac"=> 1e-12, 
-    "warm_start_slack_bound_frac"=> 1e-12, 
-    "warm_start_slack_bound_push"=> 1e-12, 
-    "warm_start_mult_bound_push" => 1e-12, 
+iter_attr = Dict(
+    "mu_init" => 1e-9,
+    "warm_start_init_point" => "yes",
+    "warm_start_bound_push" => 1e-12,
+    "warm_start_bound_frac" => 1e-12,
+    "warm_start_slack_bound_frac" => 1e-12,
+    "warm_start_slack_bound_push" => 1e-12,
+    "warm_start_mult_bound_push" => 1e-12,
     "print_level" => 0,
-    )
+)
 
-model2 = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEps=IterEps, IterAttr = IterAttr))
+model2 = BilevelModel(
+    Ipopt.Optimizer,
+    mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+)
 
 @variable(Lower(model2), q[F] >= 0)
 @variable(Upper(model2), Q >= 0)
 
-@objective(Upper(model2), Max, ((a-b * (q[1] + q[2] + Q)) * Q - C*Q) )
+@objective(Upper(model2), Max, ((a - b * (q[1] + q[2] + Q)) * Q - C * Q))
 
-@objective(Lower(model2), Min, -((a-b * (q[1] + q[2] + Q)) * q[1] - C*q[1] + (a-b * (q[1] + q[2] + Q)) * q[2] - C*q[2] + b*q[1]*q[2]) )
+@objective(
+    Lower(model2),
+    Min,
+    -(
+        (a - b * (q[1] + q[2] + Q)) * q[1] - C * q[1] + (a - b * (q[1] + q[2] + Q)) * q[2] -
+        C * q[2] + b * q[1] * q[2]
+    )
+)
 
 set_optimizer_attribute(model2, "mu_target", 1e-9)
 
@@ -115,38 +135,48 @@ optimize!(model2)
 
 # Auto testing
 
-@test isapprox(value(model2[:Q]), 60; atol=1e-6)
-@test isapprox(value.(model2[:q]).data, [20,20]; atol=1e-6) 
+@test isapprox(value(model2[:Q]), 60; atol = 1e-6)
+@test isapprox(value.(model2[:q]).data, [20, 20]; atol = 1e-6)
 
 #######################
 # Dataset 3: 
-F = [1,2]
-c = Dict(1=>1, 2=>1)
+F = [1, 2]
+c = Dict(1 => 1, 2 => 1)
 C = 2
 a = 13
 b = 0.1
 
-IterEps = [1e-0 * 0.99^i for i in 1:1500]
+iter_eps = [1e-0 * 0.99^i for i = 1:1500]
 
-IterAttr = Dict( 
-    "mu_init" => 1e-9, 
-    "warm_start_init_point"=> "yes", 
-    "warm_start_bound_push"=> 1e-12, 
-    "warm_start_bound_frac"=> 1e-12, 
-    "warm_start_slack_bound_frac"=> 1e-12, 
-    "warm_start_slack_bound_push"=> 1e-12, 
-    "warm_start_mult_bound_push" => 1e-12, 
+iter_attr = Dict(
+    "mu_init" => 1e-9,
+    "warm_start_init_point" => "yes",
+    "warm_start_bound_push" => 1e-12,
+    "warm_start_bound_frac" => 1e-12,
+    "warm_start_slack_bound_frac" => 1e-12,
+    "warm_start_slack_bound_push" => 1e-12,
+    "warm_start_mult_bound_push" => 1e-12,
     "print_level" => 0,
-    )
+)
 
-model3 = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEps=IterEps, IterAttr = IterAttr))
+model3 = BilevelModel(
+    Ipopt.Optimizer,
+    mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+)
 
 @variable(Lower(model3), q[F] >= 0)
 @variable(Upper(model3), Q >= 0)
 
-@objective(Upper(model3), Max, ((a-b * (q[1] + q[2] + Q)) * Q - C*Q) )
+@objective(Upper(model3), Max, ((a - b * (q[1] + q[2] + Q)) * Q - C * Q))
 
-@objective(Lower(model3), Min, -((a-b * (q[1] + q[2] + Q)) * q[1] - C*q[1] + (a-b * (q[1] + q[2] + Q)) * q[2] - C*q[2] + b*q[1]*q[2]) )
+@objective(
+    Lower(model3),
+    Min,
+    -(
+        (a - b * (q[1] + q[2] + Q)) * q[1] - C * q[1] + (a - b * (q[1] + q[2] + Q)) * q[2] -
+        C * q[2] + b * q[1] * q[2]
+    )
+)
 
 set_optimizer_attribute(model3, "mu_target", 1e-9)
 
@@ -154,5 +184,5 @@ optimize!(model3)
 
 # Auto testing
 
-@test isapprox(value(model3[:Q]), 55; atol=1e-6)
-@test isapprox(value.(model3[:q]).data, [18.333,18.333]; atol=1e-2) 
+@test isapprox(value(model3[:Q]), 55; atol = 1e-6)
+@test isapprox(value.(model3[:q]).data, [18.333, 18.333]; atol = 1e-2)

--- a/docs/src/examples/Iterative_example2.jl
+++ b/docs/src/examples/Iterative_example2.jl
@@ -49,7 +49,7 @@ IterAttr = Dict(
 # We can now specify our model, where the initial regularization is 1e+0, followed by setting the iterative values and settings:
 model1 = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-0;IterEps=IterEps, IterAttr = IterAttr))
 
-# The following lines are copied from the example as presented before: 
+# The following lines merge the two lower level problems into a single one. It is left to the reader to check the KKTs are indeed equivalent: 
 @variable(Lower(model1), q[F] >= 0)
 @variable(Upper(model1), Q >= 0)
 

--- a/docs/src/examples/MibS_example1.jl
+++ b/docs/src/examples/MibS_example1.jl
@@ -54,8 +54,8 @@ end)
 @objective(Lower(model), Min, y)
 
 # Lower constraints
-@constraint(Lower(model), l1,  2x -  y <= 7)
-@constraint(Lower(model), l2, -2x +  4y <= 16)
+@constraint(Lower(model), l1, 2x - y <= 7)
+@constraint(Lower(model), l2, -2x + 4y <= 16)
 @constraint(Lower(model), l3, y <= 5)
 
 # Using MibS Solver

--- a/docs/src/examples/MibS_example2.jl
+++ b/docs/src/examples/MibS_example2.jl
@@ -44,7 +44,7 @@ model = BilevelModel()
 
 # Upper constraints
 @constraints(Upper(model), begin
-    u1, -3x + 2y + 5z  <= 12
+    u1, -3x + 2y + 5z <= 12
     u2, x + 2y <= 20
     u3, x <= 10
 end)
@@ -55,8 +55,8 @@ end)
 @objective(Lower(model), Min, y)
 
 # Lower constraints
-@constraint(Lower(model), l1,  2x -  y + 3z <= 7)
-@constraint(Lower(model), l2, -2x +  4y <= 16)
+@constraint(Lower(model), l1, 2x - y + 3z <= 7)
+@constraint(Lower(model), l2, -2x + 4y <= 16)
 @constraint(Lower(model), l3, y <= 5)
 
 # Using MibS Solver

--- a/docs/src/examples/PHTP_example1.jl
+++ b/docs/src/examples/PHTP_example1.jl
@@ -43,7 +43,7 @@ atol = 1e-3
 # Then we can add the objective and constraints of the upper problem:
 
 # Upper level objecive function
-@objective(Upper(model), Min, (x-5)^2 + (2y+1)^2)
+@objective(Upper(model), Min, (x - 5)^2 + (2y + 1)^2)
 
 # Upper level constraints
 @constraint(Upper(model), x >= 0)
@@ -54,12 +54,12 @@ atol = 1e-3
 # Followed by the objective and constraints of the lower problem:
 
 # Lower objective function
-@objective(Lower(model), Min, (y-1)^2 -1.5*x*y)
+@objective(Lower(model), Min, (y - 1)^2 - 1.5 * x * y)
 
 # Lower constraints
-@constraint(Lower(model), -3x +    y <= -3)
-@constraint(Lower(model),   x - 0.5y <= 4)
-@constraint(Lower(model),   x +    y <= 7)
+@constraint(Lower(model), -3x + y <= -3)
+@constraint(Lower(model), x - 0.5y <= 4)
+@constraint(Lower(model), x + y <= 7)
 
 # Initial Starting conditions  #src
 
@@ -70,6 +70,5 @@ optimize!(model)
 primal_status(model)
 termination_status(model)
 
-@test value(x) ≈ 1 atol=atol
-@test value(y) ≈ 0 atol=atol
-
+@test value(x) ≈ 1 atol = atol
+@test value(y) ≈ 0 atol = atol

--- a/docs/src/examples/PHTP_example2.jl
+++ b/docs/src/examples/PHTP_example2.jl
@@ -33,22 +33,22 @@ model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-9))
 # First we need to create all of the variables in the upper and lower problems:
 
 # Upper level variables
-@variable(Upper(model), x[i=1:2], start = 0)
+@variable(Upper(model), x[i = 1:2], start = 0)
 
 # Lower level variables
-@variable(Lower(model), y[i=1:2], start = -10)
+@variable(Lower(model), y[i = 1:2], start = -10)
 
 # Then we can add the objective and constraints of the upper problem:
 
 # Upper level objecive function
-@objective(Upper(model), Min,2x[1] + 2x[2] -3y[1] - 3y[2] -60)
+@objective(Upper(model), Min, 2x[1] + 2x[2] - 3y[1] - 3y[2] - 60)
 
 # Upper level constraints
-@constraint(Upper(model), x[1] + x[2] + y[1] -2y[2] -40 <= 0)
-@constraint(Upper(model), [i=1:2], x[i] >= 0)
-@constraint(Upper(model), [i=1:2], x[i] <= 50)
-@constraint(Upper(model), [i=1:2], y[i] >= -10)
-@constraint(Upper(model), [i=1:2], y[i] <= 20)
+@constraint(Upper(model), x[1] + x[2] + y[1] - 2y[2] - 40 <= 0)
+@constraint(Upper(model), [i = 1:2], x[i] >= 0)
+@constraint(Upper(model), [i = 1:2], x[i] <= 50)
+@constraint(Upper(model), [i = 1:2], y[i] >= -10)
+@constraint(Upper(model), [i = 1:2], y[i] <= 20)
 
 # Followed by the objective and constraints of the lower problem:
 
@@ -56,9 +56,9 @@ model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode(1e-9))
 @objective(Lower(model), Min, (-x[1] + y[1] + 40)^2 + (-x[2] + y[2] + 20)^2)
 
 # Lower constraints
-@constraint(Lower(model),  [i=1:2],- x[i] + 2y[i] <= -10)
-@constraint(Lower(model), [i=1:2], y[i] >= -10)
-@constraint(Lower(model), [i=1:2], y[i] <= 20)
+@constraint(Lower(model), [i = 1:2], -x[i] + 2y[i] <= -10)
+@constraint(Lower(model), [i = 1:2], y[i] >= -10)
+@constraint(Lower(model), [i = 1:2], y[i] <= 20)
 
 # Now we can solve the problem and verify the solution again that reported by the book
 
@@ -67,8 +67,8 @@ primal_status(model)
 termination_status(model)
 
 # Auto testing
-@test objective_value(model) ≈ 0 atol=1e-3
+@test objective_value(model) ≈ 0 atol = 1e-3
 sol = vcat(value.(x), value.(y))
-@test sol ≈ [0 ; 0 ; -10; -10] || sol ≈ [0 ; 30; -10; 10] #atol=1e-3
+@test sol ≈ [0; 0; -10; -10] || sol ≈ [0; 30; -10; 10] #atol=1e-3
 
 # # Like any other optimization problem, there is a chance in bilevel optimization to find multiple solutions with the same optimal value; based on the inherent stochasticity of the algorithm and random seed, we are expecting two optimal solutions for this problem. 

--- a/docs/src/examples/SOCBLP_example1.jl
+++ b/docs/src/examples/SOCBLP_example1.jl
@@ -35,7 +35,10 @@ using Test
 
 
 
-model = BilevelModel(() -> MOI.Bridges.Constraint.SOCtoNonConvexQuad{Float64}(Ipopt.Optimizer()), mode = BilevelJuMP.ProductMode(1e-9))
+model = BilevelModel(
+    () -> MOI.Bridges.Constraint.SOCtoNonConvexQuad{Float64}(Ipopt.Optimizer()),
+    mode = BilevelJuMP.ProductMode(1e-9),
+)
 
 # First we need to create all of the variables in the upper and lower problems:
 
@@ -44,12 +47,12 @@ model = BilevelModel(() -> MOI.Bridges.Constraint.SOCtoNonConvexQuad{Float64}(Ip
 
 
 #Lower level variables
-@variable(Lower(model), y[i=1:2])
+@variable(Lower(model), y[i = 1:2])
 
 # Then we can add the objective and constraints of the upper problem:
 
 # Upper level objecive function
-@objective(Upper(model), Min, x + 3(y[1] -y[2]))
+@objective(Upper(model), Min, x + 3(y[1] - y[2]))
 
 # Upper level constraints
 @constraint(Upper(model), x >= 2)
@@ -58,19 +61,19 @@ model = BilevelModel(() -> MOI.Bridges.Constraint.SOCtoNonConvexQuad{Float64}(Ip
 # Followed by the objective and constraints of the lower problem:
 
 # Lower objective function
-@objective(Lower(model), Min, - (y[1] - y[2]))
+@objective(Lower(model), Min, -(y[1] - y[2]))
 
 # Lower constraints
 @constraint(Lower(model), lb_y_1, y[1] >= 0)
 @constraint(Lower(model), lb_y_2, y[2] >= 0)
-@constraint(Lower(model), con1, x +  (y[1] - y[2]) <=  8)
-@constraint(Lower(model), con2, x + 4(y[1] - y[2]) >=  8)
+@constraint(Lower(model), con1, x + (y[1] - y[2]) <= 8)
+@constraint(Lower(model), con2, x + 4(y[1] - y[2]) >= 8)
 @constraint(Lower(model), con3, x + 2(y[1] - y[2]) <= 12)
 @constraint(Lower(model), soc_lw, y in SecondOrderCone())
 
 # Defining bounds
-BilevelJuMP.set_dual_upper_bound_hint(soc_lw, +[5., 5.])
-BilevelJuMP.set_dual_lower_bound_hint(soc_lw, -[5., 5.])
+BilevelJuMP.set_dual_upper_bound_hint(soc_lw, +[5.0, 5.0])
+BilevelJuMP.set_dual_lower_bound_hint(soc_lw, -[5.0, 5.0])
 # require lower bounds
 for con in [con1, con3]
     BilevelJuMP.set_dual_lower_bound_hint(con, -15)
@@ -80,7 +83,7 @@ for con in [lb_y_1, lb_y_2, con2]
     BilevelJuMP.set_dual_upper_bound_hint(con, +15)
 end
 # bounds defined in the upper level are not dualized
-for i in 1:2
+for i = 1:2
     @constraint(Upper(model), y[i] in MOI.LessThan(+5.0))
     @constraint(Upper(model), y[i] in MOI.GreaterThan(-5.0))
 end
@@ -94,7 +97,7 @@ termination_status(model)
 
 value.(y)
 
-@test objective_value(model) ≈ 12  atol=1e-1
-@test value(x) ≈ 6 atol=1e-3
+@test objective_value(model) ≈ 12 atol = 1e-1
+@test value(x) ≈ 6 atol = 1e-3
 @test value(y[2]) >= 0 - 1e-3
-@test value(y[1]) - value(y[2]) ≈ 2 atol=1e-3
+@test value(y[1]) - value(y[2]) ≈ 2 atol = 1e-3

--- a/src/BilevelJuMP.jl
+++ b/src/BilevelJuMP.jl
@@ -8,10 +8,8 @@ using Dualization
 using LinearAlgebra
 using Printf
 
-export
-BilevelModel,
-Upper, Lower, UpperOnly, LowerOnly,
-DualOf, BilevelAffExpr, BilevelQuadExpr
+export BilevelModel,
+    Upper, Lower, UpperOnly, LowerOnly, DualOf, BilevelAffExpr, BilevelQuadExpr
 
 @enum Level LOWER_BOTH UPPER_BOTH LOWER_ONLY UPPER_ONLY DUAL_OF_LOWER
 

--- a/src/BilevelJuMP.jl
+++ b/src/BilevelJuMP.jl
@@ -6,6 +6,7 @@ const MOIU = MathOptInterface.Utilities
 using JuMP
 using Dualization
 using LinearAlgebra
+using Printf
 
 export
 BilevelModel,

--- a/src/intervals.jl
+++ b/src/intervals.jl
@@ -26,7 +26,7 @@ struct Interval{T}
     lo::T
     hi::T
 end
-function Interval(lo::T, hi::T) where {T <: Real}
+function Interval(lo::T, hi::T) where {T<:Real}
     # if hi < lo <= hi + eps(T)
     #     lo = hi
     # end
@@ -44,7 +44,7 @@ end
 function +(a::Interval{T}, b::T) where {T<:Real}
     Interval(a.lo + b, a.hi + b)
 end
-+(b::T, a::Interval{T}) where {T<:Real} = a+b
++(b::T, a::Interval{T}) where {T<:Real} = a + b
 
 function -(a::Interval{T}, b::T) where {T<:Real}
     Interval(a.lo - b, a.hi - b)
@@ -53,11 +53,11 @@ function -(b::T, a::Interval{T}) where {T<:Real}
     Interval(b - a.hi, b - a.lo)
 end
 
-function +(a::Interval{T}, b::Interval{T}) where T<:Real
+function +(a::Interval{T}, b::Interval{T}) where {T<:Real}
     Interval(a.lo + b.lo, a.hi + b.hi)
 end
 
-function -(a::Interval{T}, b::Interval{T}) where T<:Real
+function -(a::Interval{T}, b::Interval{T}) where {T<:Real}
     Interval(a.lo - b.hi, a.hi - b.lo)
 end
 
@@ -65,10 +65,10 @@ end
 function *(x::T, a::Interval{T}) where {T<:Real}
     (iszero(a) || iszero(x)) && return Interval(zero(T), zero(T))
     if x ≥ 0.0
-        return Interval(a.lo*x, a.hi*x)
+        return Interval(a.lo * x, a.hi * x)
     else
-        return Interval(a.hi*x, a.lo*x)
+        return Interval(a.hi * x, a.lo * x)
     end
 end
 
-*(a::Interval{T}, x::T) where {T<:Real} = x*a
+*(a::Interval{T}, x::T) where {T<:Real} = x * a

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -19,17 +19,17 @@ mutable struct BilevelModel <: AbstractBilevelModel
     # maps the BilevelVariableRef index
     # to JuMP variables of the correct level
     # variable that appear in both levels are inboth dicts
-    var_upper::Dict{Int, JuMP.AbstractVariableRef}
-    var_lower::Dict{Int, JuMP.AbstractVariableRef}
+    var_upper::Dict{Int,JuMP.AbstractVariableRef}
+    var_lower::Dict{Int,JuMP.AbstractVariableRef}
 
     # additional info for variables such as bound hints
     # holds the variable level: LOWER_BOTH UPPER_BOTH LOWER_ONLY UPPER_ONLY DUAL_OF_LOWER
-    var_info::Dict{Int, BilevelVariableInfo}
+    var_info::Dict{Int,BilevelVariableInfo}
 
     # maps JuMP.VariableRef to BilevelVariableRef
     # built upon necessity for getting contraints and functions
-    var_upper_rev::Union{Nothing, Dict{JuMP.AbstractVariableRef, JuMP.AbstractVariableRef}}
-    var_lower_rev::Union{Nothing, Dict{JuMP.AbstractVariableRef, JuMP.AbstractVariableRef}}
+    var_upper_rev::Union{Nothing,Dict{JuMP.AbstractVariableRef,JuMP.AbstractVariableRef}}
+    var_lower_rev::Union{Nothing,Dict{JuMP.AbstractVariableRef,JuMP.AbstractVariableRef}}
 
     # JuMP.VariableRef of variables from named level that are NOT linking
     upper_only::Set{JuMP.AbstractVariableRef}
@@ -37,56 +37,56 @@ mutable struct BilevelModel <: AbstractBilevelModel
     # upper level decisions that are "parameters" of the second level
     # keys are *decision* variables from the upper level
     # values are *parameter* variables from the lower level (linked to the keys)
-    upper_to_lower_link::Dict{JuMP.AbstractVariableRef, JuMP.AbstractVariableRef}
+    upper_to_lower_link::Dict{JuMP.AbstractVariableRef,JuMP.AbstractVariableRef}
     # lower level decisions that are input to upper
     # keys are *decision* variables from the lower level
     # values are *parameter* variables from the upper level (linked to the keys)
-    lower_to_upper_link::Dict{JuMP.AbstractVariableRef, JuMP.AbstractVariableRef}
+    lower_to_upper_link::Dict{JuMP.AbstractVariableRef,JuMP.AbstractVariableRef}
     # lower level decisions that are input to upper
     # keys are upper level variables (representing lower level dual variables)
     # values are lower level constraints
-    upper_var_to_lower_ctr_link::Dict{JuMP.AbstractVariableRef, JuMP.ConstraintRef}
+    upper_var_to_lower_ctr_link::Dict{JuMP.AbstractVariableRef,JuMP.ConstraintRef}
     # joint link
     # for all variables that appear in both models
     # keys are upper indices and values are lower indices
     # same as: merge(upper_to_lower_link, reverse(lower_to_upper_link))
-    link::Dict{JuMP.AbstractVariableRef, JuMP.AbstractVariableRef}
+    link::Dict{JuMP.AbstractVariableRef,JuMP.AbstractVariableRef}
 
     # Integer index of the last constraint added (for indexing BilevelConstraintRef's)
     nextconidx::Int
 
     # maps the BilevelConstraintRef index
     # to JuMP ConstraintRef of the correct level
-    ctr_upper::Dict{Int, JuMP.ConstraintRef}
-    ctr_lower::Dict{Int, JuMP.ConstraintRef}
+    ctr_upper::Dict{Int,JuMP.ConstraintRef}
+    ctr_lower::Dict{Int,JuMP.ConstraintRef}
 
     # additional info for constraints such as bound hints and start values
-    ctr_info::Dict{Int, BilevelConstraintInfo}
+    ctr_info::Dict{Int,BilevelConstraintInfo}
 
     # maps JuMP.ConstraintRef to BilevelConstraintRef
     # built upon necessity for getting contraints and functions
-    ctr_upper_rev::Union{Nothing, Dict{JuMP.ConstraintRef, JuMP.ConstraintRef}} # bilevel ref no defined
-    ctr_lower_rev::Union{Nothing, Dict{JuMP.ConstraintRef, JuMP.ConstraintRef}} # bilevel ref no defined
+    ctr_upper_rev::Union{Nothing,Dict{JuMP.ConstraintRef,JuMP.ConstraintRef}} # bilevel ref no defined
+    ctr_lower_rev::Union{Nothing,Dict{JuMP.ConstraintRef,JuMP.ConstraintRef}} # bilevel ref no defined
 
     #
-    solver#::MOI.ModelLike
-    mode
+    solver::Any#::MOI.ModelLike
+    mode::Any
 
     # maps for MPEC based solution methods
     # from upper level JuMP.index(JuMP.VariableRef) = (MOI.VI)
     # to mpec indices
-    upper_to_sblm
+    upper_to_sblm::Any
     # from lower MOI indices
     # to mpec indices
-    lower_to_sblm
+    lower_to_sblm::Any
     # from lower dual MOI indices
     # to mpec indices
-    lower_dual_to_sblm
+    lower_dual_to_sblm::Any
     # from mped indices to solver indices
-    sblm_to_solver
+    sblm_to_solver::Any
     # lower primal to dual map
     # to obtain dual variables from primal constraints
-    lower_primal_dual_map
+    lower_primal_dual_map::Any
 
     # results from opt process
     solve_time::Float64
@@ -98,7 +98,7 @@ mutable struct BilevelModel <: AbstractBilevelModel
     pass_start::Bool
 
     # for completing the JuMP.Model API
-    objdict::Dict{Symbol, Any}    # Same that JuMP.Model's field `objdict`
+    objdict::Dict{Symbol,Any}    # Same that JuMP.Model's field `objdict`
 
     function BilevelModel()
 
@@ -108,25 +108,25 @@ mutable struct BilevelModel <: AbstractBilevelModel
 
             # var
             0,
-            Dict{Int, JuMP.AbstractVariable}(),
-            Dict{Int, JuMP.AbstractVariable}(),
-            Dict{Int, BilevelVariableInfo}(),
+            Dict{Int,JuMP.AbstractVariable}(),
+            Dict{Int,JuMP.AbstractVariable}(),
+            Dict{Int,BilevelVariableInfo}(),
             nothing,
             nothing,
 
             # links
             Set{JuMP.AbstractVariableRef}(),
             Set{JuMP.AbstractVariableRef}(),
-            Dict{JuMP.AbstractVariable, JuMP.AbstractVariable}(),
-            Dict{JuMP.AbstractVariable, JuMP.AbstractVariable}(),
-            Dict{JuMP.AbstractVariable, JuMP.ConstraintRef}(),
-            Dict{JuMP.AbstractVariable, JuMP.AbstractVariable}(),
+            Dict{JuMP.AbstractVariable,JuMP.AbstractVariable}(),
+            Dict{JuMP.AbstractVariable,JuMP.AbstractVariable}(),
+            Dict{JuMP.AbstractVariable,JuMP.ConstraintRef}(),
+            Dict{JuMP.AbstractVariable,JuMP.AbstractVariable}(),
 
             #ctr
             0,
-            Dict{Int, JuMP.AbstractConstraint}(),
-            Dict{Int, JuMP.AbstractConstraint}(),
-            Dict{Int, BilevelConstraintInfo}(),
+            Dict{Int,JuMP.AbstractConstraint}(),
+            Dict{Int,JuMP.AbstractConstraint}(),
+            Dict{Int,BilevelConstraintInfo}(),
             nothing,
             nothing,
 
@@ -149,19 +149,20 @@ mutable struct BilevelModel <: AbstractBilevelModel
             false,
             true,
             # jump api
-            Dict{Symbol, Any}(),
-            )
+            Dict{Symbol,Any}(),
+        )
 
         return model
     end
 end
-function BilevelModel(optimizer_constructor;
-        mode::AbstractBilevelSolverMode = SOS1Mode(),
-        add_bridges::Bool=true
-    )
+function BilevelModel(
+    optimizer_constructor;
+    mode::AbstractBilevelSolverMode = SOS1Mode(),
+    add_bridges::Bool = true,
+)
     bm = BilevelModel()
     set_mode(bm, mode)
-    JuMP.set_optimizer(bm, optimizer_constructor; add_bridges=add_bridges)
+    JuMP.set_optimizer(bm, optimizer_constructor; add_bridges = add_bridges)
     return bm
 end
 function set_mode(bm::BilevelModel, mode::AbstractBilevelSolverMode)
@@ -193,12 +194,20 @@ level_both(::UpperModel) = UPPER_BOTH
 
 # obj
 
-function set_link!(m::UpperModel, upper::JuMP.AbstractVariableRef, lower::JuMP.AbstractVariableRef)
+function set_link!(
+    m::UpperModel,
+    upper::JuMP.AbstractVariableRef,
+    lower::JuMP.AbstractVariableRef,
+)
     bilevel_model(m).upper_to_lower_link[upper] = lower
     bilevel_model(m).link[upper] = lower
     nothing
 end
-function set_link!(m::LowerModel, upper::JuMP.AbstractVariableRef, lower::JuMP.AbstractVariableRef)
+function set_link!(
+    m::LowerModel,
+    upper::JuMP.AbstractVariableRef,
+    lower::JuMP.AbstractVariableRef,
+)
     bilevel_model(m).lower_to_upper_link[lower] = upper
     bilevel_model(m).link[upper] = lower
     nothing
@@ -223,7 +232,8 @@ level(::UpperOnlyModel) = UPPER_ONLY
 mylevel_var_list(m::LowerOnlyModel) = bilevel_model(m).var_lower
 mylevel_var_list(m::UpperOnlyModel) = bilevel_model(m).var_upper
 
-in_upper(l::Level) = l == LOWER_BOTH || l == UPPER_BOTH || l == UPPER_ONLY || l == DUAL_OF_LOWER
+in_upper(l::Level) =
+    l == LOWER_BOTH || l == UPPER_BOTH || l == UPPER_ONLY || l == DUAL_OF_LOWER
 in_lower(l::Level) = l == LOWER_BOTH || l == UPPER_BOTH || l == LOWER_ONLY
 
 function push_single_level_variable!(m::LowerOnlyModel, vref::JuMP.AbstractVariableRef)
@@ -245,7 +255,7 @@ function BilevelVariableRef(model::BilevelModel, idx)
 end
 
 # Constraints
-const BilevelConstraintRef = JuMP.ConstraintRef{BilevelModel, Int}#, Shape <: AbstractShape
+const BilevelConstraintRef = JuMP.ConstraintRef{BilevelModel,Int}#, Shape <: AbstractShape
 
 # Objective
 
@@ -257,7 +267,7 @@ JuMP.object_dictionary(m::AbstractBilevelModel) = JuMP.object_dictionary(bilevel
 function convert_indices(d::Dict)
     ret = Dict{VI,VI}()
     # sizehint!(ret, length(d))
-    for (k,v) in d
+    for (k, v) in d
         ret[JuMP.index(k)] = JuMP.index(v)
     end
     return ret
@@ -265,7 +275,7 @@ end
 function index2(d::Dict)
     ret = Dict{VI,CI}()
     # sizehint!(ret, length(d))
-    for (k,v) in d
+    for (k, v) in d
         ret[JuMP.index(k)] = JuMP.index(v)
     end
     return ret
@@ -356,7 +366,8 @@ function JuMP.primal_status(model::InnerBilevelModel)
 end
 
 JuMP.dual_status(::BilevelModel) = error(
-    "Dual status cant be queried for BilevelModel, but you can query for Upper and Lower models.")
+    "Dual status cant be queried for BilevelModel, but you can query for Upper and Lower models.",
+)
 function JuMP.dual_status(model::UpperModel)
     _check_solver(model.m)
     return MOI.get(model.m.solver, MOI.DualStatus())
@@ -382,7 +393,7 @@ replace_var_type(::Type{M}) where {M<:JuMP.AbstractModel} = BilevelVariableRef
 function build_reverse_var_map!(um::UpperModel)
     m = bilevel_model(um)
     if m.var_upper_rev === nothing
-        m.var_upper_rev = Dict{JuMP.AbstractVariableRef, BilevelVariableRef}()
+        m.var_upper_rev = Dict{JuMP.AbstractVariableRef,BilevelVariableRef}()
         for (idx, ref) in m.var_upper
             m.var_upper_rev[ref] = BilevelVariableRef(m, idx)
         end
@@ -392,7 +403,7 @@ end
 function build_reverse_var_map!(lm::LowerModel)
     m = bilevel_model(lm)
     if m.var_lower_rev === nothing
-        m.var_lower_rev = Dict{JuMP.AbstractVariableRef, BilevelVariableRef}()
+        m.var_lower_rev = Dict{JuMP.AbstractVariableRef,BilevelVariableRef}()
         for (idx, ref) in m.var_lower
             m.var_lower_rev[ref] = BilevelVariableRef(m, idx)
         end
@@ -405,48 +416,64 @@ function reverse_replace_variable(f, m::InnerBilevelModel)
     build_reverse_var_map!(m)
     return replace_variables(f, mylevel_model(m), get_reverse_var_map(m), level(m))
 end
-function replace_variables(var::VV, # JuMP.VariableRef
+function replace_variables(
+    var::VV, # JuMP.VariableRef
     model::M,
-    variable_map::Dict{I, V},
-    level::Level) where {I,V<:JuMP.AbstractVariableRef, M, VV<:JuMP.AbstractVariableRef}
+    variable_map::Dict{I,V},
+    level::Level,
+) where {I,V<:JuMP.AbstractVariableRef,M,VV<:JuMP.AbstractVariableRef}
     return variable_map[var]
 end
-function replace_variables(var::BilevelVariableRef,
+function replace_variables(
+    var::BilevelVariableRef,
     model::M,
-    variable_map::Dict{I, V},
-    level::Level) where {I,V<:JuMP.AbstractVariableRef, M<:BilevelModel}
+    variable_map::Dict{I,V},
+    level::Level,
+) where {I,V<:JuMP.AbstractVariableRef,M<:BilevelModel}
     if var.model === model && in_level(var, level)
         return variable_map[var.idx]
     elseif var.model === model
-        error("Variable $(var) belonging Only to $(var.level) level, was added in the $(level) level.")
+        error(
+            "Variable $(var) belonging Only to $(var.level) level, was added in the $(level) level.",
+        )
     else
-        error("A BilevelModel cannot have expression using variables of a BilevelModel different from itself")
+        error(
+            "A BilevelModel cannot have expression using variables of a BilevelModel different from itself",
+        )
     end
 end
-function replace_variables(aff::JuMP.GenericAffExpr{C, VV},
+function replace_variables(
+    aff::JuMP.GenericAffExpr{C,VV},
     model::M,
-    variable_map::Dict{I, V},
-    level::Level) where {I,C,V<:JuMP.AbstractVariableRef, M, VV}
-    result = JuMP.GenericAffExpr{C, replace_var_type(M)}(0.0)#zero(aff)
+    variable_map::Dict{I,V},
+    level::Level,
+) where {I,C,V<:JuMP.AbstractVariableRef,M,VV}
+    result = JuMP.GenericAffExpr{C,replace_var_type(M)}(0.0)#zero(aff)
     result.constant = aff.constant
     for (coef, var) in JuMP.linear_terms(aff)
-        JuMP.add_to_expression!(result,
-        coef,
-        replace_variables(var, model, variable_map, level))
+        JuMP.add_to_expression!(
+            result,
+            coef,
+            replace_variables(var, model, variable_map, level),
+        )
     end
     return result
 end
-function replace_variables(quad::JuMP.GenericQuadExpr{C, VV},
+function replace_variables(
+    quad::JuMP.GenericQuadExpr{C,VV},
     model::M,
-    variable_map::Dict{I, V},
-    level::Level) where {I,C,V<:JuMP.AbstractVariableRef, M, VV}
+    variable_map::Dict{I,V},
+    level::Level,
+) where {I,C,V<:JuMP.AbstractVariableRef,M,VV}
     aff = replace_variables(quad.aff, model, variable_map, level)
-    quadv = JuMP.GenericQuadExpr{C, replace_var_type(M)}(aff)
+    quadv = JuMP.GenericQuadExpr{C,replace_var_type(M)}(aff)
     for (coef, var1, var2) in JuMP.quad_terms(quad)
-        JuMP.add_to_expression!(quadv,
-        coef,
-        replace_variables(var1, model, variable_map, level),
-        replace_variables(var2, model, variable_map, level))
+        JuMP.add_to_expression!(
+            quadv,
+            coef,
+            replace_variables(var1, model, variable_map, level),
+            replace_variables(var2, model, variable_map, level),
+        )
     end
     return quadv
 end
@@ -462,11 +489,19 @@ end
 
 JuMP.optimize!(::T) where {T<:AbstractBilevelModel} =
     error("Can't solve a model of type: $T ")
-function JuMP.optimize!(model::BilevelModel;
-    lower_prob = "", upper_prob = "", bilevel_prob = "", solver_prob = "", file_format = MOI.FileFormats.FORMAT_AUTOMATIC)
+function JuMP.optimize!(
+    model::BilevelModel;
+    lower_prob = "",
+    upper_prob = "",
+    bilevel_prob = "",
+    solver_prob = "",
+    file_format = MOI.FileFormats.FORMAT_AUTOMATIC,
+)
 
     if model.mode === nothing
-        error("No solution mode selected, use `set_mode(model, mode)` or initialize with `BilevelModel(optimizer_constructor, mode = some_mode)`")
+        error(
+            "No solution mode selected, use `set_mode(model, mode)` or initialize with `BilevelModel(optimizer_constructor, mode = some_mode)`",
+        )
     else
         mode = model.mode
     end
@@ -497,8 +532,7 @@ function JuMP.optimize!(model::BilevelModel;
 
     t0 = time()
 
-    moi_upper = JuMP.index.(
-        collect(values(model.upper_to_lower_link)))
+    moi_upper = JuMP.index.(collect(values(model.upper_to_lower_link)))
     moi_link = convert_indices(model.link)
     moi_link2 = index2(model.upper_var_to_lower_ctr_link)
 
@@ -507,8 +541,16 @@ function JuMP.optimize!(model::BilevelModel;
     build_bounds!(model, mode)
 
     single_blm, upper_to_sblm, lower_to_sblm, lower_primal_dual_map, lower_dual_to_sblm =
-        build_bilevel(upper, lower, moi_link, moi_upper, mode, moi_link2,
-            copy_names = model.copy_names, pass_start = model.pass_start)
+        build_bilevel(
+            upper,
+            lower,
+            moi_link,
+            moi_upper,
+            mode,
+            moi_link2,
+            copy_names = model.copy_names,
+            pass_start = model.pass_start,
+        )
 
     # pass additional info (hints - not actual problem data)
     # for lower level dual variables (start, upper hint, lower hint)
@@ -518,7 +560,7 @@ function JuMP.optimize!(model::BilevelModel;
             # this fails for vector-constrained variables due dualization 0.3.5
             # because of constrained variables that change the dual
             pre_duals = lower_primal_dual_map.primal_con_dual_var[JuMP.index(ctr)] # vector
-            duals = map(x->lower_dual_to_sblm[x], pre_duals)
+            duals = map(x -> lower_dual_to_sblm[x], pre_duals)
             pass_dual_info(single_blm, duals, info)
         end
     end
@@ -538,7 +580,7 @@ function JuMP.optimize!(model::BilevelModel;
     end
 
     sblm_to_solver = MOI.copy_to(solver, single_blm)
-    
+
     if _has_nlp_data(model.upper)
         # NLP requires an upstream jump model
         # probably is neough to have the fields:
@@ -592,14 +634,12 @@ end
 
 function pass_primal_info(single_blm, primal, info::BilevelVariableInfo)
     if !isnan(info.upper) &&
-        !MOI.is_valid(single_blm, CI{MOI.VariableIndex,LT{Float64}}(primal.value))
-        MOI.add_constraint(single_blm,
-            primal, LT{Float64}(info.upper))
+       !MOI.is_valid(single_blm, CI{MOI.VariableIndex,LT{Float64}}(primal.value))
+        MOI.add_constraint(single_blm, primal, LT{Float64}(info.upper))
     end
     if !isnan(info.lower) &&
-        !MOI.is_valid(single_blm, CI{MOI.VariableIndex,GT{Float64}}(primal.value))
-        MOI.add_constraint(single_blm,
-            primal, GT{Float64}(info.lower))
+       !MOI.is_valid(single_blm, CI{MOI.VariableIndex,GT{Float64}}(primal.value))
+        MOI.add_constraint(single_blm, primal, GT{Float64}(info.lower))
     end
     return
 end
@@ -609,14 +649,12 @@ function pass_dual_info(single_blm, dual, info::BilevelConstraintInfo{Float64})
         MOI.set(single_blm, MOI.VariablePrimalStart(), dual[], info.start)
     end
     if !isnan(info.upper) &&
-        !MOI.is_valid(single_blm, CI{MOI.VariableIndex,LT{Float64}}(dual[].value))
-        MOI.add_constraint(single_blm,
-            dual[], LT{Float64}(info.upper))
+       !MOI.is_valid(single_blm, CI{MOI.VariableIndex,LT{Float64}}(dual[].value))
+        MOI.add_constraint(single_blm, dual[], LT{Float64}(info.upper))
     end
     if !isnan(info.lower) &&
-        !MOI.is_valid(single_blm, CI{MOI.VariableIndex,GT{Float64}}(dual[].value))
-        MOI.add_constraint(single_blm,
-            dual[], GT{Float64}(info.lower))
+       !MOI.is_valid(single_blm, CI{MOI.VariableIndex,GT{Float64}}(dual[].value))
+        MOI.add_constraint(single_blm, dual[], GT{Float64}(info.lower))
     end
     return
 end
@@ -626,14 +664,12 @@ function pass_dual_info(single_blm, dual, info::BilevelConstraintInfo{Vector{Flo
             MOI.set(single_blm, MOI.VariablePrimalStart(), dual[i], info.start[i])
         end
         if !isnan(info.upper[i]) &&
-            !MOI.is_valid(single_blm, CI{MOI.VariableIndex,LT{Float64}}(dual[i].value))
-            MOI.add_constraint(single_blm,
-                dual[i], LT{Float64}(info.upper[i]))
+           !MOI.is_valid(single_blm, CI{MOI.VariableIndex,LT{Float64}}(dual[i].value))
+            MOI.add_constraint(single_blm, dual[i], LT{Float64}(info.upper[i]))
         end
         if !isnan(info.lower[i]) &&
-            !MOI.is_valid(single_blm, CI{MOI.VariableIndex,GT{Float64}}(dual[i].value))
-            MOI.add_constraint(single_blm,
-                dual[i], MOI.GreaterThan{Float64}(info.lower[i]))
+           !MOI.is_valid(single_blm, CI{MOI.VariableIndex,GT{Float64}}(dual[i].value))
+            MOI.add_constraint(single_blm, dual[i], MOI.GreaterThan{Float64}(info.lower[i]))
         end
     end
     return
@@ -707,13 +743,13 @@ inf_if_nan(::typeof(+), val) = ifelse(isnan(val), Inf, val)
 inf_if_nan(::typeof(-), val) = ifelse(isnan(val), -Inf, val)
 
 dual_lower_bound(::CI{F,LT{T}}) where {F,T} = -Inf
-dual_upper_bound(::CI{F,LT{T}}) where {F,T} =  0.0
+dual_upper_bound(::CI{F,LT{T}}) where {F,T} = 0.0
 
-dual_lower_bound(::CI{F,GT{T}}) where {F,T} =  0.0
+dual_lower_bound(::CI{F,GT{T}}) where {F,T} = 0.0
 dual_upper_bound(::CI{F,GT{T}}) where {F,T} = +Inf
 
-dual_lower_bound(::CI{F,ET{T}}) where {F,T} =  0.0
-dual_upper_bound(::CI{F,ET{T}}) where {F,T} =  0.0
+dual_lower_bound(::CI{F,ET{T}}) where {F,T} = 0.0
+dual_upper_bound(::CI{F,ET{T}}) where {F,T} = 0.0
 
 dual_lower_bound(::CI{F,S}) where {F,S} = -Inf
 dual_upper_bound(::CI{F,S}) where {F,S} = +Inf
@@ -722,17 +758,22 @@ dual_upper_bound(::CI{F,S}) where {F,S} = +Inf
 
 function _check_solver(bm::BilevelModel)
     if bm.solver === nothing
-        error("No solver attached, use `set_optimizer(model, optimizer_constructor)` or initialize with `BilevelModel(optimizer_constructor)`")
+        error(
+            "No solver attached, use `set_optimizer(model, optimizer_constructor)` or initialize with `BilevelModel(optimizer_constructor)`",
+        )
     end
 end
 
-function JuMP.set_optimizer(bm::BilevelModel, optimizer_constructor;
-    add_bridges::Bool=true)
+function JuMP.set_optimizer(
+    bm::BilevelModel,
+    optimizer_constructor;
+    add_bridges::Bool = true,
+)
     # error_if_direct_mode(model, :set_optimizer)
     if add_bridges
         # If `default_copy_to` without names is supported,
         # no need for a second cache.
-        optimizer = MOI.instantiate(optimizer_constructor, with_bridge_type=Float64)
+        optimizer = MOI.instantiate(optimizer_constructor, with_bridge_type = Float64)
         # for bridge_type in model.bridge_types
         #     _moi_add_bridge(optimizer, bridge_type)
         # end
@@ -748,20 +789,21 @@ function JuMP.set_optimizer(bm::BilevelModel, optimizer_constructor;
 end
 
 
-function pass_cache(bm::BilevelModel, mode::FortunyAmatMcCarlMode{T}) where T
+function pass_cache(bm::BilevelModel, mode::FortunyAmatMcCarlMode{T}) where {T}
     mode.cache = bm.mode.cache
     return nothing
 end
-function pass_cache(bm::BilevelModel, mode::AbstractBilevelSolverMode{T}) where T
+function pass_cache(bm::BilevelModel, mode::AbstractBilevelSolverMode{T}) where {T}
     return nothing
 end
 
-function check_mixed_mode(::MixedMode{T}) where T
-end
+function check_mixed_mode(::MixedMode{T}) where {T} end
 function check_mixed_mode(mode)
-    error("Cant set/get mode on a specific object because the base mode is $mode while it should be MixedMode in this case. Run `set_mode(model, BilevelJuMP.MixedMode())`")
+    error(
+        "Cant set/get mode on a specific object because the base mode is $mode while it should be MixedMode in this case. Run `set_mode(model, BilevelJuMP.MixedMode())`",
+    )
 end
-function set_mode(ci::BilevelConstraintRef, mode::AbstractBilevelSolverMode{T}) where T
+function set_mode(ci::BilevelConstraintRef, mode::AbstractBilevelSolverMode{T}) where {T}
     bm = ci.model
     check_mixed_mode(bm.mode)
     _mode = deepcopy(mode)
@@ -789,15 +831,15 @@ function get_mode(ci::BilevelConstraintRef)
     end
 end
 
-function set_mode(::BilevelConstraintRef, ::MixedMode{T}) where T
+function set_mode(::BilevelConstraintRef, ::MixedMode{T}) where {T}
     error("Cant set MixedMode in a specific constraint")
 end
-function set_mode(::BilevelConstraintRef, ::StrongDualityMode{T}) where T
+function set_mode(::BilevelConstraintRef, ::StrongDualityMode{T}) where {T}
     error("Cant set StrongDualityMode in a specific constraint")
 end
 
 # mode for variable bounds
-function set_mode(vi::BilevelVariableRef, mode::AbstractBilevelSolverMode{T}) where T
+function set_mode(vi::BilevelVariableRef, mode::AbstractBilevelSolverMode{T}) where {T}
     bm = vi.model
     check_mixed_mode(bm.mode)
     _mode = deepcopy(mode)
@@ -826,10 +868,10 @@ function get_mode(vi::BilevelVariableRef)
     end
 end
 
-function set_mode(::BilevelVariableRef, ::MixedMode{T}) where T
+function set_mode(::BilevelVariableRef, ::MixedMode{T}) where {T}
     error("Cant set MixedMode in a specific variable")
 end
-function set_mode(::BilevelVariableRef, ::StrongDualityMode{T}) where T
+function set_mode(::BilevelVariableRef, ::StrongDualityMode{T}) where {T}
     error("Cant set StrongDualityMode in a specific variable")
 end
 
@@ -843,162 +885,323 @@ function MOI.set(::BilevelModel, ::MOI.HeuristicCallback, func)
     error("Callbacks are not available in BilevelJuMP Models")
 end
 
-function iterative_optimize!(solver, mode, single_blm, model, t0) nothing end
+function iterative_optimize!(solver, mode, single_blm, model, t0)
+    nothing
+end
 
-function iterative_optimize!(solver, mode::ProductMode{T}, single_blm, model::BilevelModel, t0) where T
-    if isempty(mode.IterativeEpsilon)
+function iterative_optimize!(
+    solver,
+    mode::ProductMode{T},
+    single_blm,
+    model::BilevelModel,
+    t0,
+) where {T}
+
+    if isempty(mode.iter_eps)
         return nothing
     end
 
-    TerminationEpsilon = mode.epsilon
+    termination_eps = mode.epsilon
 
     if MOI.get(solver, MOI.PrimalStatus()) in [FEASIBLE_POINT, NEARLY_FEASIBLE_POINT]
-        for (attr,val) in mode.IterativeAttributes
-            MOI.set(solver,MOI.RawOptimizerAttribute(attr),val)
+
+        for (attr, val) in mode.iter_attr
+            MOI.set(solver, MOI.RawOptimizerAttribute(attr), val)
         end
+
         println("Starting iterative ProductMode(), printing log below: ")
-        _print_iter_log(;Iteration=0, Regularization=mode.epsilon, TerminationStatus=MOI.get(solver, MOI.TerminationStatus()), PrimalStatus=MOI.get(solver, MOI.PrimalStatus()), ObjectiveValue=MOI.get(solver, MOI.ObjectiveValue()), t=time()-t0, upperline=true, header=true)
-        
+        print_iter_log(;
+            iteration = 0,
+            regularization = mode.epsilon,
+            termination_status = MOI.get(solver, MOI.TerminationStatus()),
+            primal_status = MOI.get(solver, MOI.PrimalStatus()),
+            objective_value = MOI.get(solver, MOI.ObjectiveValue()),
+            t = time() - t0,
+            upperline = true,
+            header = true,
+        )
+
         if MOI.supports_incremental_interface(solver)
             comp_idxs_in_solver = get_solver_comp_idxs(model, mode)
-            TerminationEpsilon = _iterative_optimize_solver!(solver, mode, comp_idxs_in_solver, t0)
+            termination_eps =
+                iterative_optimize_solver(solver, mode, comp_idxs_in_solver, t0)
         else
-            TerminationEpsilon = _iterative_optimize_copy!(single_blm, solver, mode, model, t0)
+            termination_eps = iterative_optimize_copy(single_blm, solver, mode, model, t0)
         end
+
     else
-        @warn "Unable to start iterative ProductMode(). You may want to retry with a larger initial regularizer. For more information see below:"
+        error(
+            "Unable to start iterative ProductMode() because initial solution is not feasible. You may want to retry with a larger initial regularizer. For more information take a look at the solver log. ",
+        )
     end
 
-    _print_iter_log(;Iteration="Terminated", Regularization=TerminationEpsilon, TerminationStatus=MOI.get(solver, MOI.TerminationStatus()), PrimalStatus=MOI.get(solver, MOI.PrimalStatus()), ObjectiveValue=MOI.get(solver, MOI.ObjectiveValue()), t=time()-t0, upperline=true, header=true, bottomline=true)
+    print_iter_log(;
+        iteration = "Terminated",
+        regularization = termination_eps,
+        termination_status = MOI.get(solver, MOI.TerminationStatus()),
+        primal_status = MOI.get(solver, MOI.PrimalStatus()),
+        objective_value = MOI.get(solver, MOI.ObjectiveValue()),
+        t = time() - t0,
+        upperline = true,
+        header = true,
+        bottomline = true,
+    )
 
     return nothing
 
 end
 
-function get_solver_comp_idxs(model::BilevelModel, mode::ProductMode{T}) where T
-    [model.sblm_to_solver[comp_idx_in_sblm] for comp_idx_in_sblm in mode.comp_idx_in_sblm ]
+function get_solver_comp_idxs(model::BilevelModel, mode::ProductMode{T}) where {T}
+
+    return [
+        model.sblm_to_solver[comp_idx_in_sblm] for comp_idx_in_sblm in mode.comp_idx_in_sblm
+    ]
+
 end
 
-function _iterative_optimize_solver!(solver, mode::ProductMode{T}, comp_idxs_in_solver::Vector{MathOptInterface.ConstraintIndex{F, S}}, t0) where {T, F, S}
-    for (iter,eps) in enumerate(mode.IterativeEpsilon)
+function iterative_optimize_solver(
+    solver,
+    mode::ProductMode{T},
+    comp_idxs_in_solver::Vector{MathOptInterface.ConstraintIndex{F,S}},
+    t0,
+) where {T,F,S}
 
-        SetIterPrimalStarts!(solver)
-        SetIterDualStarts!(solver)
-        SetIterRegularizations!(solver, eps, comp_idxs_in_solver, S)
+    for (iter, eps) in enumerate(mode.iter_eps)
+
+        set_iter_primal_starts(solver)
+        set_iter_dual_starts(solver)
+        set_iter_regularizations(solver, eps, comp_idxs_in_solver, S)
 
         MOI.optimize!(solver)
 
-        _print_iter_log(;Iteration="s$(iter)", Regularization=eps, TerminationStatus=MOI.get(solver, MOI.TerminationStatus()), PrimalStatus=MOI.get(solver, MOI.PrimalStatus()), ObjectiveValue=MOI.get(solver, MOI.ObjectiveValue()), t=time()-t0)
+        print_iter_log(;
+            iteration = "s$(iter)",
+            regularization = eps,
+            termination_status = MOI.get(solver, MOI.TerminationStatus()),
+            primal_status = MOI.get(solver, MOI.PrimalStatus()),
+            objective_value = MOI.get(solver, MOI.ObjectiveValue()),
+            t = time() - t0,
+        )
 
-        TerminationEpsilon = eps
+        termination_eps = eps
 
         if MOI.get(solver, MOI.PrimalStatus()) ∉ [FEASIBLE_POINT, NEARLY_FEASIBLE_POINT]
-            return TerminationEpsilon
+            return termination_eps
         end
+
     end
-    return mode.IterativeEpsilon[end]
+
+    return mode.iter_eps[end]
+
 end
 
-function _iterative_optimize_copy!(single_blm, solver, mode::ProductMode{T}, model::BilevelModel, t0) where T
-    for (iter,eps) in enumerate(mode.IterativeEpsilon)
-        SetIterPrimalStarts!(single_blm, solver, model.sblm_to_solver)
-        SetIterDualStarts!(single_blm, solver, model.sblm_to_solver)
-        SetIterRegularizations!(single_blm, eps, mode.comp_idx_in_sblm)
-        
+function iterative_optimize_copy(
+    single_blm,
+    solver,
+    mode::ProductMode{T},
+    model::BilevelModel,
+    t0,
+) where {T}
+
+    for (iter, eps) in enumerate(mode.iter_eps)
+
+        set_iter_primal_starts(single_blm, solver, model.sblm_to_solver)
+        set_iter_dual_starts(single_blm, solver, model.sblm_to_solver)
+        set_iter_regularizations(single_blm, eps, mode.comp_idx_in_sblm)
+
         MOI.empty!(solver)
         model.sblm_to_solver = MOI.copy_to(solver, single_blm)
 
         MOI.optimize!(solver)
 
-        _print_iter_log(;Iteration="c$(iter)", Regularization=eps, TerminationStatus=MOI.get(solver, MOI.TerminationStatus()), PrimalStatus=MOI.get(solver, MOI.PrimalStatus()), ObjectiveValue=MOI.get(solver, MOI.ObjectiveValue()), t=time()-t0)
+        print_iter_log(;
+            iteration = "c$(iter)",
+            regularization = eps,
+            termination_status = MOI.get(solver, MOI.TerminationStatus()),
+            primal_status = MOI.get(solver, MOI.PrimalStatus()),
+            objective_value = MOI.get(solver, MOI.ObjectiveValue()),
+            t = time() - t0,
+        )
 
-        TerminationEpsilon = eps
+        termination_eps = eps
 
         if MOI.get(solver, MOI.PrimalStatus()) ∉ [FEASIBLE_POINT, NEARLY_FEASIBLE_POINT]
-            return TerminationEpsilon
+            return termination_eps
         end
+
     end
-    return mode.IterativeEpsilon[end]
+
+    return mode.iter_eps[end]
+
 end
 
-function _print_iter_log(;Iteration, Regularization, TerminationStatus, PrimalStatus, ObjectiveValue, t, header=false, bottomline=false, upperline=false)
-    colwidth = Dict(:Iteration=>11, :Regularization=>20, :TerminationStatus=>25, :PrimalStatus=>25, :ObjectiveValue=>25, :t=>15)
+function print_iter_log(;
+    iteration,
+    regularization,
+    termination_status,
+    primal_status,
+    objective_value,
+    t,
+    header = false,
+    bottomline = false,
+    upperline = false,
+)
+
+    colwidth = Dict(
+        :iteration => 11,
+        :regularization => 20,
+        :termination_status => 25,
+        :primal_status => 25,
+        :objective_value => 25,
+        :t => 15,
+    )
+
     if upperline
-        println(repeat("-",sum(values(colwidth))))
+        println(repeat("-", sum(values(colwidth))))
     end
+
     if header
-        println(lpad("Iteration", colwidth[:Iteration]),lpad("Regularization", colwidth[:Regularization]),lpad("Termination Status", colwidth[:TerminationStatus]),lpad("Primal Status", colwidth[:PrimalStatus]), lpad("Objective Value", colwidth[:ObjectiveValue]), lpad("Time",colwidth[:t]) )
+        println(
+            lpad("Iteration", colwidth[:iteration]),
+            lpad("Regularization", colwidth[:regularization]),
+            lpad("Termination Status", colwidth[:termination_status]),
+            lpad("Primal Status", colwidth[:primal_status]),
+            lpad("Objective Value", colwidth[:objective_value]),
+            lpad("Time", colwidth[:t]),
+        )
     end
-    if PrimalStatus ∈ [FEASIBLE_POINT, NEARLY_FEASIBLE_POINT]
-        println(lpad(Iteration, colwidth[:Iteration]),lpad(Printf.@sprintf("%.5e",Regularization), colwidth[:Regularization]),lpad(TerminationStatus, colwidth[:TerminationStatus]),lpad(PrimalStatus, colwidth[:PrimalStatus]), lpad(Printf.@sprintf("%.8e",ObjectiveValue), colwidth[:ObjectiveValue]), lpad(Printf.@sprintf("%.2f",t),colwidth[:t]) )
+
+    if primal_status in [FEASIBLE_POINT, NEARLY_FEASIBLE_POINT]
+        println(
+            lpad(iteration, colwidth[:iteration]),
+            lpad(Printf.@sprintf("%.5e", regularization), colwidth[:regularization]),
+            lpad(termination_status, colwidth[:termination_status]),
+            lpad(primal_status, colwidth[:primal_status]),
+            lpad(Printf.@sprintf("%.8e", objective_value), colwidth[:objective_value]),
+            lpad(Printf.@sprintf("%.2f", t), colwidth[:t]),
+        )
     else
-        println(lpad(Iteration, colwidth[:Iteration]),lpad(Printf.@sprintf("%.5e",Regularization), colwidth[:Regularization]),lpad(TerminationStatus, colwidth[:TerminationStatus]),lpad(PrimalStatus, colwidth[:PrimalStatus]), lpad(repeat('-', 14), colwidth[:ObjectiveValue]), lpad(Printf.@sprintf("%.2f",t),colwidth[:t]) )
+        println(
+            lpad(iteration, colwidth[:iteration]),
+            lpad(Printf.@sprintf("%.5e", regularization), colwidth[:regularization]),
+            lpad(termination_status, colwidth[:termination_status]),
+            lpad(primal_status, colwidth[:primal_status]),
+            lpad(repeat('-', 14), colwidth[:objective_value]),
+            lpad(Printf.@sprintf("%.2f", t), colwidth[:t]),
+        )
     end
+
     if bottomline
-        println(repeat("-",sum(values(colwidth))))
+        println(repeat("-", sum(values(colwidth))))
     end
+
 end
 
-function SetIterPrimalStarts!(single_blm, solver, sblm_to_solver)
-    for VarIdx in MOI.get(single_blm, MOI.ListOfVariableIndices())::Vector{MOI.VariableIndex}
-        solverVarIdx = sblm_to_solver[VarIdx]
-        MOI.set(single_blm, MOI.VariablePrimalStart(), VarIdx, MOI.get(solver, MOI.VariablePrimal(), solverVarIdx))
+function set_iter_primal_starts(single_blm, solver, sblm_to_solver)
+
+    for var_idx in
+        MOI.get(single_blm, MOI.ListOfVariableIndices())::Vector{MOI.VariableIndex}
+        solver_var_idx = sblm_to_solver[VarIdx]
+        MOI.set(
+            single_blm,
+            MOI.VariablePrimalStart(),
+            var_idx,
+            MOI.get(solver, MOI.VariablePrimal(), solver_var_idx),
+        )
     end
+
 end
 
-function SetIterDualStarts!(single_blm, solver, sblm_to_solver)
+function set_iter_dual_starts(single_blm, solver, sblm_to_solver)
+
     for (F, S) in MOI.get(single_blm, MOI.ListOfConstraintTypesPresent())
-        _SetIterDualStart!(single_blm, F, S, solver, sblm_to_solver)
+        set_iter_dual_start(single_blm, F, S, solver, sblm_to_solver)
     end
+
 end
 
-function _SetIterDualStart!(single_blm, F, S, solver, sblm_to_solver)
-    for CtrIdx in MOI.get(single_blm, MOI.ListOfConstraintIndices{F,S}())
-        solverCtrIdx = sblm_to_solver[CtrIdx]
-        MOI.set(single_blm, MOI.ConstraintDualStart(), CtrIdx, MOI.get(solver, MOI.ConstraintDual(), solverCtrIdx))
+function set_iter_dual_start(single_blm, F, S, solver, sblm_to_solver)
+
+    for ctr_idx in MOI.get(single_blm, MOI.ListOfConstraintIndices{F,S}())
+        solver_ctr_idx = sblm_to_solver[ctr_idx]
+        MOI.set(
+            single_blm,
+            MOI.ConstraintDualStart(),
+            ctr_idx,
+            MOI.get(solver, MOI.ConstraintDual(), solver_ctr_idx),
+        )
     end
+
 end
 
-function _SetIterDualStart!(single_blm, F::MOI.VectorAffineFunction, S, solver, sblm_to_solver)
+function set_iter_dual_start(
+    single_blm,
+    F::MOI.VectorAffineFunction,
+    S,
+    solver,
+    sblm_to_solver,
+)
     error("Vector valued functions not yet supported in iterative ProductMode()")
 end
 
-function SetIterRegularizations!(m, eps, comp_idxs)
-    for CtrIdx in comp_idxs
-        MOI.set(m, MOI.ConstraintSet(), CtrIdx,MOI.LessThan(eps))
+function set_iter_regularizations(m, eps, comp_idxs)
+
+    for ctr_idx in comp_idxs
+        MOI.set(m, MOI.ConstraintSet(), ctr_idx, MOI.LessThan(eps))
     end
+
 end
 
-function SetIterRegularizations!(m, eps, comp_idxs, S::Type{MOI.LessThan{T}}) where T
-    for CtrIdx in comp_idxs
-        MOI.set(m, MOI.ConstraintSet(), CtrIdx,MOI.LessThan(eps))
+function set_iter_regularizations(m, eps, comp_idxs, S::Type{MOI.LessThan{T}}) where {T}
+
+    for ctr_idx in comp_idxs
+        MOI.set(m, MOI.ConstraintSet(), ctr_idx, MOI.LessThan(eps))
     end
+
 end
 
-function SetIterRegularizations!(m, eps, comp_idxs, S::Type{MOI.GreaterThan{T}}) where T
-    for CtrIdx in comp_idxs
-        MOI.set(m, MOI.ConstraintSet(), CtrIdx,MOI.GreaterThan(-1*eps))
+function set_iter_regularizations(m, eps, comp_idxs, S::Type{MOI.GreaterThan{T}}) where {T}
+
+    for ctr_idx in comp_idxs
+        MOI.set(m, MOI.ConstraintSet(), ctr_idx, MOI.GreaterThan(-1 * eps))
     end
+
 end
 
-function SetIterPrimalStarts!(solver)
-    for VarIdx in MOI.get(solver, MOI.ListOfVariableIndices())::Vector{MOI.VariableIndex}
-        MOI.set(solver, MOI.VariablePrimalStart(), VarIdx, MOI.get(solver, MOI.VariablePrimal(), VarIdx))
+function set_iter_primal_starts(solver)
+
+    for var_idx in MOI.get(solver, MOI.ListOfVariableIndices())::Vector{MOI.VariableIndex}
+        MOI.set(
+            solver,
+            MOI.VariablePrimalStart(),
+            var_idx,
+            MOI.get(solver, MOI.VariablePrimal(), var_idx),
+        )
     end
+
 end
 
-function SetIterDualStarts!(solver)
+function set_iter_dual_starts(solver)
+
     for (F, S) in MOI.get(solver, MOI.ListOfConstraintTypesPresent())
-        _SetIterDualStart!(F, S, solver)
+        set_iter_dual_start(F, S, solver)
     end
+
 end
 
-function _SetIterDualStart!(F, S, solver)
-    for CtrIdx in MOI.get(solver, MOI.ListOfConstraintIndices{F,S}())
-        MOI.set(solver, MOI.ConstraintDualStart(), CtrIdx, MOI.get(solver, MOI.ConstraintDual(), CtrIdx))
+function set_iter_dual_start(F, S, solver)
+
+    for ctr_idx in MOI.get(solver, MOI.ListOfConstraintIndices{F,S}())
+        MOI.set(
+            solver,
+            MOI.ConstraintDualStart(),
+            ctr_idx,
+            MOI.get(solver, MOI.ConstraintDual(), ctr_idx),
+        )
     end
+
 end
 
-function _SetIterDualStart!(F::MOI.VectorAffineFunction, S, solver)
+function set_iter_dual_start(F::MOI.VectorAffineFunction, S, solver)
     error("Vector valued functions not yet supported in iterative ProductMode()")
 end

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -497,6 +497,7 @@ function JuMP.optimize!(
     solver_prob = "",
     file_format = MOI.FileFormats.FORMAT_AUTOMATIC,
     show_iter_log = true,
+    consider_constrained_variables = false,
 )
 
     if model.mode === nothing
@@ -551,6 +552,7 @@ function JuMP.optimize!(
             moi_link2,
             copy_names = model.copy_names,
             pass_start = model.pass_start,
+            consider_constrained_variables = consider_constrained_variables,
         )
 
     # pass additional info (hints - not actual problem data)

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -888,7 +888,7 @@ function _iterative_optimize_solver!(solver, mode, comp_idxs_in_solver, t0)
 
         MOI.optimize!(solver)
 
-        _print_iter_log(;Iteration="$(iter)s", Regularization=eps, TerminationStatus=MOI.get(solver, MOI.TerminationStatus()), PrimalStatus=MOI.get(solver, MOI.PrimalStatus()), ObjectiveValue=MOI.get(solver, MOI.ObjectiveValue()), t=time()-t0)
+        _print_iter_log(;Iteration="s$(iter)", Regularization=eps, TerminationStatus=MOI.get(solver, MOI.TerminationStatus()), PrimalStatus=MOI.get(solver, MOI.PrimalStatus()), ObjectiveValue=MOI.get(solver, MOI.ObjectiveValue()), t=time()-t0)
 
         TerminationEpsilon = eps
 
@@ -908,19 +908,9 @@ function _iterative_optimize_copy!(single_blm, solver, mode, model, t0)
         MOI.empty!(solver)
         model.sblm_to_solver = MOI.copy_to(solver, single_blm)
 
-        # There seems to be a bug (or feature) that duals to variable bounds are sometimes not copied by MOI.copy_to for Ipopt. The following loop is a workaround, but shouldn't stay...
-        for (F, S) in MOI.get(single_blm, MOI.ListOfConstraintTypesPresent())
-            if F in [MOI.VariableIndex]
-                for CtrIdx in MOI.get(single_blm, MOI.ListOfConstraintIndices{F,S}())
-                    solverCtrIdx = model.sblm_to_solver[CtrIdx]
-                    MOI.set(solver, MOI.ConstraintDualStart(), solverCtrIdx, MOI.get(single_blm, MOI.ConstraintDualStart(), CtrIdx))
-                end
-            end
-        end
-
         MOI.optimize!(solver)
 
-        _print_iter_log(;Iteration="$(iter)c", Regularization=eps, TerminationStatus=MOI.get(solver, MOI.TerminationStatus()), PrimalStatus=MOI.get(solver, MOI.PrimalStatus()), ObjectiveValue=MOI.get(solver, MOI.ObjectiveValue()), t=time()-t0)
+        _print_iter_log(;Iteration="c$(iter)", Regularization=eps, TerminationStatus=MOI.get(solver, MOI.TerminationStatus()), PrimalStatus=MOI.get(solver, MOI.PrimalStatus()), ObjectiveValue=MOI.get(solver, MOI.ObjectiveValue()), t=time()-t0)
 
         TerminationEpsilon = eps
 

--- a/src/jump_attributes.jl
+++ b/src/jump_attributes.jl
@@ -10,7 +10,9 @@ function JuMP.set_optimizer_attribute(bm::BilevelModel, name::String, value)
     return JuMP.set_optimizer_attribute(bm, MOI.RawOptimizerAttribute(name), value)
 end
 function JuMP.set_optimizer_attribute(
-    bm::BilevelModel, attr::MOI.AbstractOptimizerAttribute, value
+    bm::BilevelModel,
+    attr::MOI.AbstractOptimizerAttribute,
+    value,
 )
     _check_solver(bm)
     return MOI.set(bm.solver, attr, value)
@@ -26,7 +28,8 @@ function JuMP.get_optimizer_attribute(bm::BilevelModel, name::String)
     return JuMP.get_optimizer_attribute(bm.solver, MOI.RawOptimizerAttribute(name))
 end
 function JuMP.get_optimizer_attribute(
-    bm::BilevelModel, attr::MOI.AbstractOptimizerAttribute
+    bm::BilevelModel,
+    attr::MOI.AbstractOptimizerAttribute,
 )
     _check_solver(bm)
     return MOI.get(bm.solver, attr)

--- a/src/jump_constraints.jl
+++ b/src/jump_constraints.jl
@@ -20,19 +20,24 @@ function BilevelConstraintRef(model, idx)
     return JuMP.ConstraintRef(model, idx, raw.shape)
 end
 level(cref::BilevelConstraintRef) = cref.model.ctr_info[cref.index].level
-function JuMP.add_constraint(::BilevelModel, ::JuMP.AbstractConstraint, ::String="")
+function JuMP.add_constraint(::BilevelModel, ::JuMP.AbstractConstraint, ::String = "")
     error(
-        "Can't add constraint directly to the bilevel model `m`, "*
-        "attach the constraint to the upper or lower model "*
-        "with @constraint(Upper(m), ...) or @constraint(Lower(m), ...)")
+        "Can't add constraint directly to the bilevel model `m`, " *
+        "attach the constraint to the upper or lower model " *
+        "with @constraint(Upper(m), ...) or @constraint(Lower(m), ...)",
+    )
 end
-function JuMP.constraint_object(con_ref::ConstraintRef{BilevelModel, Int})
+function JuMP.constraint_object(con_ref::ConstraintRef{BilevelModel,Int})
     raw = raw_ref(con_ref)
     return JuMP.constraint_object(raw)
 end
 # JuMP.add_constraint(m::UpperModel, c::JuMP.VectorConstraint, name::String="") =
 #     error("no vec ctr")
-function JuMP.add_constraint(m::InnerBilevelModel, c::Union{JuMP.ScalarConstraint{F,S},JuMP.VectorConstraint{F,S}}, name::String="") where {F,S}
+function JuMP.add_constraint(
+    m::InnerBilevelModel,
+    c::Union{JuMP.ScalarConstraint{F,S},JuMP.VectorConstraint{F,S}},
+    name::String = "",
+) where {F,S}
     blm = bilevel_model(m)
     blm.nextconidx += 1
     cref = JuMP.ConstraintRef(blm, blm.nextconidx, JuMP.shape(c))
@@ -84,27 +89,36 @@ end
 
 function _assert_dim(cref, array::Vector, value::Vector)
     if length(array) != length(value)
-        error("For the Vector constraint {$(cref)}, expected a Vector of length = $(length(array)) and got a Vector of length = $(length(value))")
+        error(
+            "For the Vector constraint {$(cref)}, expected a Vector of length = $(length(array)) and got a Vector of length = $(length(value))",
+        )
     end
     return
 end
 function _assert_dim(cref, array::Vector, value::Number)
-    error("For the Vector constraint {$(cref)}, expected a Vector (of length = $(length(array))) and got the scalar $value")
+    error(
+        "For the Vector constraint {$(cref)}, expected a Vector (of length = $(length(array))) and got the scalar $value",
+    )
     return
 end
 function _assert_dim(cref, array::Number, value::Number)
     return
 end
 function _assert_dim(cref, array::Number, value::Vector)
-    error("For the Scalar constraint {$(cref)}, expected a Scalar and got the Vector $(value)")
+    error(
+        "For the Scalar constraint {$(cref)}, expected a Scalar and got the Vector $(value)",
+    )
     return
 end
 
-function JuMP.set_dual_start_value(cref::BilevelConstraintRef, value::T) where T<:Number
+function JuMP.set_dual_start_value(cref::BilevelConstraintRef, value::T) where {T<:Number}
     _assert_dim(cref, cref.model.ctr_info[cref.index].start, value)
     cref.model.ctr_info[cref.index].start = value
 end
-function JuMP.set_dual_start_value(cref::BilevelConstraintRef, value::T) where T<:Vector{S} where S
+function JuMP.set_dual_start_value(
+    cref::BilevelConstraintRef,
+    value::T,
+) where {T<:Vector{S}} where {S}
     array = cref.model.ctr_info[cref.index].start
     _assert_dim(cref, array, value)
     copyto!(array, value)
@@ -113,11 +127,14 @@ function JuMP.dual_start_value(cref::BilevelConstraintRef)
     cref.model.ctr_info[cref.index].start
 end
 
-function set_dual_upper_bound_hint(cref::BilevelConstraintRef, value::T) where T<:Number
+function set_dual_upper_bound_hint(cref::BilevelConstraintRef, value::T) where {T<:Number}
     _assert_dim(cref, cref.model.ctr_info[cref.index].upper, value)
     cref.model.ctr_info[cref.index].upper = value
 end
-function set_dual_upper_bound_hint(cref::BilevelConstraintRef, value::T) where T<:Vector{S} where S
+function set_dual_upper_bound_hint(
+    cref::BilevelConstraintRef,
+    value::T,
+) where {T<:Vector{S}} where {S}
     array = cref.model.ctr_info[cref.index].upper
     _assert_dim(cref, array, value)
     copyto!(array, value)
@@ -125,11 +142,14 @@ end
 function get_dual_upper_bound_hint(cref::BilevelConstraintRef)
     cref.model.ctr_info[cref.index].upper
 end
-function set_dual_lower_bound_hint(cref::BilevelConstraintRef, value::T) where T<:Number
+function set_dual_lower_bound_hint(cref::BilevelConstraintRef, value::T) where {T<:Number}
     _assert_dim(cref, cref.model.ctr_info[cref.index].lower, value)
     cref.model.ctr_info[cref.index].lower = value
 end
-function set_dual_lower_bound_hint(cref::BilevelConstraintRef, value::T) where T<:Vector{S} where S
+function set_dual_lower_bound_hint(
+    cref::BilevelConstraintRef,
+    value::T,
+) where {T<:Vector{S}} where {S}
     array = cref.model.ctr_info[cref.index].lower
     _assert_dim(cref, array, value)
     copyto!(array, value)
@@ -138,13 +158,13 @@ function get_dual_lower_bound_hint(cref::BilevelConstraintRef)
     cref.model.ctr_info[cref.index].lower
 end
 
-function set_primal_upper_bound_hint(vref::BilevelVariableRef, value::T) where T<:Number
+function set_primal_upper_bound_hint(vref::BilevelVariableRef, value::T) where {T<:Number}
     vref.model.var_info[vref.idx].upper = value
 end
 function get_primal_upper_bound_hint(vref::BilevelVariableRef)
     vref.model.var_info[vref.idx].upper
 end
-function set_primal_lower_bound_hint(vref::BilevelVariableRef, value::T) where T<:Number
+function set_primal_lower_bound_hint(vref::BilevelVariableRef, value::T) where {T<:Number}
     vref.model.var_info[vref.idx].lower = value
 end
 function get_primal_lower_bound_hint(vref::BilevelVariableRef)
@@ -185,7 +205,7 @@ function JuMP.num_constraints(model::InnerBilevelModel, f, s)
 end
 function JuMP.num_constraints(model::BilevelModel, f, s)
     return JuMP.num_constraints(Upper(model), f, s) +
-        JuMP.num_constraints(Lower(model), f, s)
+           JuMP.num_constraints(Lower(model), f, s)
 end
 
 struct DualOf
@@ -201,7 +221,7 @@ function DualOf(::AbstractArray{<:T}) where {T<:JuMP.ConstraintRef}
         "@variable(Upper(m), my_variable[t=1:N], " *
         "DualOf(my_constraint_vector[t]))\n" *
         "Or use anonynous variables:\n" *
-        "@variable(Upper(m), variable_type = DualOf(my_constraint_vector[t]))"
+        "@variable(Upper(m), variable_type = DualOf(my_constraint_vector[t]))",
     )
 end
 struct DualVariableInfo
@@ -216,7 +236,9 @@ function JuMP.build_variable(
 )
 
     if level(dual_of.ci) != LOWER_ONLY
-        error("Variables can only be tied to LOWER level constraints, got $(dual_of.ci.level) level")
+        error(
+            "Variables can only be tied to LOWER level constraints, got $(dual_of.ci.level) level",
+        )
     end
     for (kwarg, _) in extra_kw_args
         _error("Unrecognized keyword argument $kwarg")
@@ -232,25 +254,24 @@ function JuMP.build_variable(
         # info.has_ub = false
         # info.upper_bound = NaN
     end
-    info.has_fix   && _error("Dual variable does not support fixing")
+    info.has_fix && _error("Dual variable does not support fixing")
     if info.has_start
         JuMP.set_dual_start_value(dual_of.ci, info.start)
         # info.has_start = false
         # info.start = NaN
     end
-    info.binary    && _error("Dual variable cannot be binary")
-    info.integer   && _error("Dual variable cannot be integer")
+    info.binary && _error("Dual variable cannot be binary")
+    info.integer && _error("Dual variable cannot be integer")
 
-    info = JuMP.VariableInfo(false, NaN, false, NaN,
-                             false, NaN, false, NaN,
-                             false, false)
+    info = JuMP.VariableInfo(false, NaN, false, NaN, false, NaN, false, NaN, false, false)
 
-    return DualVariableInfo(
-        info,
-        dual_of.ci
-    )
+    return DualVariableInfo(info, dual_of.ci)
 end
-function JuMP.add_variable(inner::UpperModel, dual_info::DualVariableInfo, name::String="")
+function JuMP.add_variable(
+    inner::UpperModel,
+    dual_info::DualVariableInfo,
+    name::String = "",
+)
     # TODO vector version
     m = bilevel_model(inner)
     m.last_variable_index += 1
@@ -297,21 +318,17 @@ function JuMP.dual(cref::BilevelConstraintRef)
             push!(solver_var_idxs, cref.model.sblm_to_solver[vi])
         end
         pre_duals = MOI.get(cref.model.solver, MOI.VariablePrimal(), solver_var_idxs)
-        return JuMP.reshape_vector(
-            pre_duals,
-            JuMP.dual_shape(con_lower_ref.shape)
-            )
+        return JuMP.reshape_vector(pre_duals, JuMP.dual_shape(con_lower_ref.shape))
     elseif in_upper(cref)
         m = cref.model
         con_upper_ref = cref.model.ctr_upper[cref.index]
         solver_ctr_idx = m.sblm_to_solver[m.upper_to_sblm[JuMP.index(con_upper_ref)]]
         pre_duals = MOI.get(cref.model.solver, MOI.ConstraintDual(), solver_ctr_idx)
-        return JuMP.reshape_vector(
-            pre_duals,
-            JuMP.dual_shape(con_upper_ref.shape)
-            )
+        return JuMP.reshape_vector(pre_duals, JuMP.dual_shape(con_upper_ref.shape))
     else
-        error("Dual solutions of upper level constraints are not available. Either the solution method does nto porvide duals or or the solver failed to get one.")
+        error(
+            "Dual solutions of upper level constraints are not available. Either the solution method does nto porvide duals or or the solver failed to get one.",
+        )
     end
 end
 
@@ -338,7 +355,10 @@ function JuMP.normalized_coefficient(cref::BilevelConstraintRef, var::BilevelVar
 end
 
 function JuMP.set_normalized_coefficient(
-    cref::BilevelConstraintRef, var::BilevelVariableRef, val)
+    cref::BilevelConstraintRef,
+    var::BilevelVariableRef,
+    val,
+)
     model = cref.model
     level_var = if in_upper(cref)
         model.var_upper[var.idx]
@@ -356,17 +376,21 @@ end
 function JuMP.list_of_constraint_types(
     model::BilevelModel,
 )::Vector{Tuple{DataType,DataType}}
-    return unique!(vcat(
-        JuMP.list_of_constraint_types(Upper(model)),
-        JuMP.list_of_constraint_types(Lower(model)),
-    ))
+    return unique!(
+        vcat(
+            JuMP.list_of_constraint_types(Upper(model)),
+            JuMP.list_of_constraint_types(Lower(model)),
+        ),
+    )
 end
 
 function JuMP.all_constraints(model::BilevelModel, f, s)
-    return unique!(vcat(
-        JuMP.all_constraints(Upper(model), f, s),
-        JuMP.all_constraints(Lower(model), f, s),
-    ))
+    return unique!(
+        vcat(
+            JuMP.all_constraints(Upper(model), f, s),
+            JuMP.all_constraints(Lower(model), f, s),
+        ),
+    )
 end
 
 function JuMP.all_constraints(model::InnerBilevelModel, f, s)
@@ -377,14 +401,14 @@ function JuMP.all_constraints(model::InnerBilevelModel, f, s)
 end
 function build_reverse_ctr_map!(um::UpperModel)
     m = bilevel_model(um)
-    m.ctr_upper_rev = Dict{JuMP.ConstraintRef, JuMP.ConstraintRef}()
+    m.ctr_upper_rev = Dict{JuMP.ConstraintRef,JuMP.ConstraintRef}()
     for (idx, ref) in m.ctr_upper
         m.ctr_upper_rev[ref] = BilevelConstraintRef(m, idx)
     end
 end
 function build_reverse_ctr_map!(lm::LowerModel)
     m = bilevel_model(lm)
-    m.ctr_lower_rev = Dict{JuMP.ConstraintRef, JuMP.ConstraintRef}()
+    m.ctr_lower_rev = Dict{JuMP.ConstraintRef,JuMP.ConstraintRef}()
     for (idx, ref) in m.ctr_lower
         m.ctr_lower_rev[ref] = BilevelConstraintRef(m, idx)
     end

--- a/src/jump_nlp.jl
+++ b/src/jump_nlp.jl
@@ -6,7 +6,7 @@
 =#
 
 function _has_nlp_data(model)
-    return  model.nlp_data !== nothing
+    return model.nlp_data !== nothing
 end
 function _load_nlp_data(model)
     # callen in JuMP.optimize!
@@ -73,7 +73,8 @@ function JuMP.set_objective(
     m.nlp_data.nlobj = ex
     return
 end
-function JuMP.set_objective(::LowerModel,
+function JuMP.set_objective(
+    ::LowerModel,
     ::MOI.OptimizationSense,
     ::JuMP._NonlinearExprData,
 )
@@ -86,7 +87,13 @@ function JuMP._parse_NL_expr_runtime(m::UpperModel, x, tape, parent, values)
     return nothing
 end
 
-function JuMP._parse_NL_expr_runtime(m::UpperModel, x::BilevelVariableRef, tape, parent, values)
+function JuMP._parse_NL_expr_runtime(
+    m::UpperModel,
+    x::BilevelVariableRef,
+    tape,
+    parent,
+    values,
+)
     if !in_upper(x)
         error(
             "Variable in nonlinear expression does not belong to the " *

--- a/src/jump_objective.jl
+++ b/src/jump_objective.jl
@@ -1,13 +1,15 @@
 function JuMP.set_objective_sense(m::InnerBilevelModel, sense::MOI.OptimizationSense)
     JuMP.set_objective_sense(mylevel_model(m), sense)
 end
-function JuMP.set_objective(m::InnerBilevelModel, sense::MOI.OptimizationSense,
-    f::JuMP.AbstractJuMPScalar)
+function JuMP.set_objective(
+    m::InnerBilevelModel,
+    sense::MOI.OptimizationSense,
+    f::JuMP.AbstractJuMPScalar,
+)
     level_f = replace_variables(f, bilevel_model(m), mylevel_var_list(m), level(m))
     JuMP.set_objective(mylevel_model(m), sense, level_f)
 end
-function JuMP.set_objective(m::InnerBilevelModel, sense::MOI.OptimizationSense,
-    f::Real)
+function JuMP.set_objective(m::InnerBilevelModel, sense::MOI.OptimizationSense, f::Real)
     JuMP.set_objective(mylevel_model(m), sense, f)
 end
 JuMP.objective_sense(m::InnerBilevelModel) = JuMP.objective_sense(mylevel_model(m))
@@ -16,13 +18,11 @@ function JuMP.objective_function_type(m::InnerBilevelModel)
     return bilevel_type(m, tp)
 end
 bilevel_type(::InnerBilevelModel, ::Type{JuMP.VariableRef}) = BilevelVariableRef
-function bilevel_type(::InnerBilevelModel, ::Type{JuMP.GenericAffExpr{C, V}}
-) where {C, V}
-    JuMP.GenericAffExpr{C, BilevelVariableRef}
+function bilevel_type(::InnerBilevelModel, ::Type{JuMP.GenericAffExpr{C,V}}) where {C,V}
+    JuMP.GenericAffExpr{C,BilevelVariableRef}
 end
-function bilevel_type(::InnerBilevelModel, ::Type{JuMP.GenericQuadExpr{C, V}}
-) where {C, V}
-    JuMP.GenericAffExpr{C, BilevelVariableRef}
+function bilevel_type(::InnerBilevelModel, ::Type{JuMP.GenericQuadExpr{C,V}}) where {C,V}
+    JuMP.GenericAffExpr{C,BilevelVariableRef}
 end
 # JuMP.objective_function(m::InnerBilevelModel) = mylevel_obj_function(m)
 function JuMP.objective_function(m::InnerBilevelModel)
@@ -43,7 +43,7 @@ end
 function JuMP.relative_gap(bm::UpperModel)::Float64
     return JuMP.relative_gap(bm.m)
 end
-function JuMP.dual_objective_value(bm::BilevelModel; result::Int=1)::Float64
+function JuMP.dual_objective_value(bm::BilevelModel; result::Int = 1)::Float64
     _check_solver(bm)
     return MOI.get(bm.solver, MOI.DualObjectiveValue(result))
 end
@@ -55,8 +55,11 @@ function JuMP.objective_bound(bm::UpperModel)::Float64
     return JuMP.objective_bound(bm.m)
 end
 
-function JuMP.set_objective(m::BilevelModel, sense::MOI.OptimizationSense,
-    f::JuMP.AbstractJuMPScalar)
+function JuMP.set_objective(
+    m::BilevelModel,
+    sense::MOI.OptimizationSense,
+    f::JuMP.AbstractJuMPScalar,
+)
     bilevel_obj_error()
 end
 JuMP.objective_sense(m::BilevelModel) = JuMP.objective_sense(m.upper)# bilevel_obj_error()
@@ -66,7 +69,8 @@ function JuMP.objective_function(model::BilevelModel, FT::Type)
     bilevel_obj_error()
 end
 
-bilevel_obj_error() = error("There is no objective for BilevelModel use Upper(.) and Lower(.)")
+bilevel_obj_error() =
+    error("There is no objective for BilevelModel use Upper(.) and Lower(.)")
 
 function JuMP.objective_value(model::BilevelModel)
     _check_solver(model)
@@ -88,16 +92,20 @@ function lower_objective_value(model::BilevelModel; result::Int = 1)
 end
 
 function JuMP.set_objective_coefficient(
-    ::UpperModel, variable::BilevelVariableRef, coeff::Real)
+    ::UpperModel,
+    variable::BilevelVariableRef,
+    coeff::Real,
+)
     level_var = variable.model.var_upper[variable.idx]
     model = JuMP.owner_model(level_var)
-    JuMP.set_objective_coefficient(
-        model, level_var, coeff)
+    JuMP.set_objective_coefficient(model, level_var, coeff)
 end
 function JuMP.set_objective_coefficient(
-    ::LowerModel, variable::BilevelVariableRef, coeff::Real)
+    ::LowerModel,
+    variable::BilevelVariableRef,
+    coeff::Real,
+)
     level_var = variable.model.var_lower[variable.idx]
     model = JuMP.owner_model(level_var)
-    JuMP.set_objective_coefficient(
-        model, level_var, coeff)
+    JuMP.set_objective_coefficient(model, level_var, coeff)
 end

--- a/src/jump_print.jl
+++ b/src/jump_print.jl
@@ -10,9 +10,10 @@ function JuMP.show_constraints_summary(io::IO, model::UpperModel)
 end
 function JuMP.show_constraints_summary(io::IO, model::LowerModel, line_break = false)
     n = JuMP.num_constraints(model)
-    print(io, "Lower Constraint", _plural(n), ": ", n, ifelse(line_break, "\n",""))
+    print(io, "Lower Constraint", _plural(n), ": ", n, ifelse(line_break, "\n", ""))
 end
-JuMP.show_backend_summary(io::IO, model::InnerBilevelModel) = JuMP.show_backend_summary(io, model.m)
+JuMP.show_backend_summary(io::IO, model::InnerBilevelModel) =
+    JuMP.show_backend_summary(io, model.m)
 function JuMP.show_backend_summary(io::IO, model::BilevelModel)
     println(io, "Bilevel Model")
     println(io, "Solution method: ", model.mode)
@@ -36,15 +37,12 @@ function JuMP.solver_name(model::BilevelModel)
 end
 
 function JuMP.show_objective_function_summary(io::IO, model::UpperModel)
-    println(io, "Upper objective function type: \n",
-            JuMP.objective_function_type(model))
+    println(io, "Upper objective function type: \n", JuMP.objective_function_type(model))
 end
 function JuMP.show_objective_function_summary(io::IO, model::LowerModel)
-    println(io, "Lower objective function type: \n",
-            JuMP.objective_function_type(model))
+    println(io, "Lower objective function type: \n", JuMP.objective_function_type(model))
 end
 function JuMP.show_objective_function_summary(io::IO, model::BilevelModel)
     JuMP.show_objective_function_summary(io, Upper(model))
     JuMP.show_objective_function_summary(io, Lower(model))
 end
-

--- a/src/moi.jl
+++ b/src/moi.jl
@@ -90,11 +90,14 @@ end
 
 mutable struct ProductMode{T} <: AbstractBilevelSolverMode{T}
     epsilon::T
+    IterativeEpsilon::Vector{T}
     with_slack::Bool
+    comp_idx_in_sblm::Vector{CI}
     aggregation_group::Int # only useful in mixed mode
     function_cache::Union{Nothing, MOI.AbstractScalarFunction}
     function ProductMode(
         eps::T=zero(Float64);
+        ItEps::Vector{T}=T[],
         with_slack::Bool = false,
         aggregation_group = nothing
     ) where T<:Float64 # Real
@@ -103,7 +106,9 @@ mutable struct ProductMode{T} <: AbstractBilevelSolverMode{T}
         # positive integers point to their numbers
         return new{Float64}(
             eps,
+            ItEps,
             with_slack,
+            Vector{CI}(),
             aggregation_group === nothing ? 0 : aggregation_group,
             nothing,
             )
@@ -178,6 +183,7 @@ function reset!(mode::FortunyAmatMcCarlMode)
 end
 function reset!(mode::ProductMode)
     mode.function_cache = nothing
+    mode.comp_idx_in_sblm = Vector{CI}()
     return nothing
 end
 function reset!(mode::MixedMode)
@@ -794,6 +800,7 @@ function add_complement(mode::ProductMode{T}, m, comp::Complement,
             add_function_to_cache(mode, new_f)
         end
     end
+    appush!(mode.comp_idx_in_sblm,out_ctr)
     return out_var, out_ctr
 end
 

--- a/src/moi.jl
+++ b/src/moi.jl
@@ -287,6 +287,52 @@ end
 accept_vector_set(::ProductMode{T}, ::Complement) where {T} = nothing
 accept_vector_set(::MixedMode{T}, ::Complement) where {T} = nothing
 
+function get_variable_complement(primal_model, dual_model, primal_con, dual_con) 
+    error("An internal error with variable complements occurred. Likely, your problem type does not yet support consideration of constrained variables. If you are certain it does, a sign flip or something else did not work as expected in Dualization.jl ...")
+end
+
+function get_variable_complement(primal_model, dual_model, primal_con::MOI.ConstraintIndex{Fp,Sp}, dual_con::MOI.ConstraintIndex{Fd,Sd}) where {Fp<:MOI.VariableIndex,Sp<:MOI.GreaterThan{T},Fd,Sd<:MOI.GreaterThan{T}} where T
+    primal_variable = MOI.get(primal_model, MOI.ConstraintFunction(), primal_con)
+    primal_set =  MOI.get(primal_model, MOI.ConstraintSet(), primal_con)
+
+    @assert MOI.constant(primal_set) == 0 "Unexpected variable bound"
+
+    dual_func = MOI.get(dual_model, MOI.ConstraintFunction(), dual_con)
+    dual_set = MOI.get(dual_model, MOI.ConstraintSet(), dual_con)
+    if MOI.constant(dual_set) > 0
+        dual_func.constant = dual_func.constant - MOI.constant(dual_set)
+    elseif MOI.constant(dual_set) < 0
+        dual_func.constant = dual_func.constant + MOI.constant(dual_set)
+    end
+    return Complement(false, primal_con, dual_func, set_with_zero(dual_set), primal_variable)
+end
+
+function get_variable_complement(primal_model, dual_model, primal_con::MOI.ConstraintIndex{Fp,Sp}, dual_con::MOI.ConstraintIndex{Fd,Sd}) where {Fp<:MOI.VariableIndex,Sp<:MOI.LessThan{T},Fd,Sd<:MOI.LessThan{T}} where T
+    primal_variable = MOI.get(primal_model, MOI.ConstraintFunction(), primal_con)
+    primal_set =  MOI.get(primal_model, MOI.ConstraintSet(), primal_con)
+
+    @assert MOI.constant(primal_set) == 0 "Unexpected variable bound"
+
+    dual_func = MOI.get(dual_model, MOI.ConstraintFunction(), dual_con)
+    dual_set = MOI.get(dual_model, MOI.ConstraintSet(), dual_con)
+    if MOI.constant(dual_set) > 0
+        dual_func.constant = dual_func.constant - MOI.constant(dual_set)
+    elseif MOI.constant(dual_set) < 0
+        dual_func.constant = dual_func.constant + MOI.constant(dual_set)
+    end
+    return Complement(false, primal_con, dual_func, set_with_zero(dual_set), primal_variable)
+end
+
+function get_variable_complements(primal_model, dual_model, primal_dual_map)
+    map = primal_dual_map.primal_con_dual_var
+    out = Complement[]
+    for (primal_con, dual_con) in primal_dual_map.constrained_var_dual
+        con = get_variable_complement(primal_model, dual_model, primal_con, dual_con)
+        push!(out, con)
+    end
+    return out
+end
+
 function get_canonical_complements(primal_model, primal_dual_map)
     map = primal_dual_map.primal_con_dual_var
     out = Complement[]
@@ -342,6 +388,7 @@ function build_bilevel(
     upper_var_to_lower_ctr::Dict{VI,CI} = Dict{VI,CI}();
     copy_names::Bool = false,
     pass_start::Bool = false,
+    consider_constrained_variables::Bool = false
 )
 
     # Start with an empty problem
@@ -357,7 +404,7 @@ function build_bilevel(
         dual_names = DualNames("dual_", "dual_"),
         variable_parameters = upper_variables,
         ignore_objective = ignore_dual_objective(mode),
-        consider_constrained_variables = false,
+        consider_constrained_variables = consider_constrained_variables,
     )
     # the model
     lower_dual = dual_problem.dual_model
@@ -471,6 +518,27 @@ function build_bilevel(
                 )
             else
                 # feasible equality constraints always satisfy complementarity
+            end
+        end
+
+        if consider_constrained_variables
+            # complementary slackness for variable bounds
+            variable_comps = get_variable_complements(lower, lower_dual, lower_primal_dual_map)
+            for comp in variable_comps
+                if !is_equality(comp.set_w_zero)
+                    accept_vector_set(mode, comp)
+                    add_complement(
+                        mode,
+                        m,
+                        comp,
+                        lower_dual_idxmap,
+                        lower_idxmap,
+                        copy_names,
+                        pass_start,
+                    )
+                else
+                    # feasible equality constraints always satisfy complementarity
+                end
             end
         end
     else # strong duality

--- a/src/moi.jl
+++ b/src/moi.jl
@@ -91,13 +91,15 @@ end
 mutable struct ProductMode{T} <: AbstractBilevelSolverMode{T}
     epsilon::T
     IterativeEpsilon::Vector{T}
+    IterativeAttributes
     with_slack::Bool
     comp_idx_in_sblm::Vector{CI}
     aggregation_group::Int # only useful in mixed mode
     function_cache::Union{Nothing, MOI.AbstractScalarFunction}
     function ProductMode(
         eps::T=zero(Float64);
-        ItEps::Vector{T}=T[],
+        IterEps::Vector{T}=T[],
+        IterAttr=Dict(),
         with_slack::Bool = false,
         aggregation_group = nothing
     ) where T<:Float64 # Real
@@ -106,7 +108,8 @@ mutable struct ProductMode{T} <: AbstractBilevelSolverMode{T}
         # positive integers point to their numbers
         return new{Float64}(
             eps,
-            ItEps,
+            IterEps,
+            IterAttr,
             with_slack,
             Vector{CI}(),
             aggregation_group === nothing ? 0 : aggregation_group,

--- a/src/moi.jl
+++ b/src/moi.jl
@@ -10,19 +10,13 @@ const GT = MOI.GreaterThan
 const LT = MOI.LessThan
 const ET = MOI.EqualTo
 
-const SCALAR_SETS = Union{
-    MOI.GreaterThan{Float64},
-    MOI.LessThan{Float64},
-    MOI.EqualTo{Float64},
-}
+const SCALAR_SETS =
+    Union{MOI.GreaterThan{Float64},MOI.LessThan{Float64},MOI.EqualTo{Float64}}
 
-const VECTOR_SETS = Union{
-    MOI.SecondOrderCone,
-    MOI.RotatedSecondOrderCone,
-}
+const VECTOR_SETS = Union{MOI.SecondOrderCone,MOI.RotatedSecondOrderCone}
 
 # dual variable info
-mutable struct BilevelConstraintInfo{T<:Union{Float64, Vector{Float64}}}
+mutable struct BilevelConstraintInfo{T<:Union{Float64,Vector{Float64}}}
     level::Level
     start::T
     upper::T
@@ -35,7 +29,7 @@ mutable struct BilevelConstraintInfo{T<:Union{Float64, Vector{Float64}}}
     end
 end
 
-mutable struct BilevelVariableInfo{T<:Union{Float64, Vector{Float64}}}
+mutable struct BilevelVariableInfo{T<:Union{Float64,Vector{Float64}}}
     level::Level
     upper::T
     lower::T
@@ -46,7 +40,7 @@ mutable struct BilevelVariableInfo{T<:Union{Float64, Vector{Float64}}}
         new{Vector{Float64}}(level, fill(NaN, N), fill(NaN, N))
     end
 end
-function BilevelVariableInfo(_info::BilevelConstraintInfo{T}) where T
+function BilevelVariableInfo(_info::BilevelConstraintInfo{T}) where {T}
     if isa(_info.upper, Number)
         info = BilevelVariableInfo(DUAL_OF_LOWER)
         info.lower = _info.lower
@@ -60,20 +54,19 @@ function BilevelVariableInfo(_info::BilevelConstraintInfo{T}) where T
 end
 
 struct Complement#{M1 <: MOI.ModelLike, M2 <: MOI.ModelLike, F, S}
-    is_vec
+    is_vec::Any
     # primal::M1
-    constraint
-    func_w_cte#::F
-    set_w_zero#::S
+    constraint::Any
+    func_w_cte::Any#::F
+    set_w_zero::Any#::S
     # dual::M2
-    variable#::VI
+    variable::Any#::VI
     # var_set#::S2
 end
 
 abstract type AbstractBilevelSolverMode{T} end
 
-mutable struct NoMode{T} <: AbstractBilevelSolverMode{T}
-end
+mutable struct NoMode{T} <: AbstractBilevelSolverMode{T} end
 
 mutable struct SOS1Mode{T} <: AbstractBilevelSolverMode{T}
     function SOS1Mode()
@@ -83,38 +76,38 @@ end
 
 mutable struct ComplementMode{T} <: AbstractBilevelSolverMode{T}
     with_slack::Bool
-    function ComplementMode(;with_slack = false)
+    function ComplementMode(; with_slack = false)
         return new{Float64}(with_slack)
     end
 end
 
 mutable struct ProductMode{T} <: AbstractBilevelSolverMode{T}
     epsilon::T
-    IterativeEpsilon::Vector{T}
-    IterativeAttributes
+    iter_eps::Vector{T}
+    iter_attr::Any
     with_slack::Bool
     comp_idx_in_sblm::Vector{CI}
     aggregation_group::Int # only useful in mixed mode
-    function_cache::Union{Nothing, MOI.AbstractScalarFunction}
+    function_cache::Union{Nothing,MOI.AbstractScalarFunction}
     function ProductMode(
-        eps::T=zero(Float64);
-        IterEps::Vector{T}=T[],
-        IterAttr=Dict(),
+        eps::T = zero(Float64);
+        iter_eps = T[],
+        iter_attr = Dict(),
         with_slack::Bool = false,
-        aggregation_group = nothing
-    ) where T<:Float64 # Real
+        aggregation_group = nothing,
+    ) where {T<:Float64} # Real
         @assert aggregation_group === nothing || aggregation_group >= 1
         # nothing means individualized
         # positive integers point to their numbers
         return new{Float64}(
             eps,
-            IterEps,
-            IterAttr,
+            iter_eps,
+            iter_attr,
             with_slack,
-            Vector{CI}(),
+            CI[],
             aggregation_group === nothing ? 0 : aggregation_group,
             nothing,
-            )
+        )
     end
 end
 
@@ -129,17 +122,17 @@ end
 
 struct ComplementBoundCache
     # internal usage
-    upper::Dict{VI, BilevelVariableInfo}
-    lower::Dict{VI, BilevelVariableInfo}
-    ldual::Dict{CI, BilevelConstraintInfo}
+    upper::Dict{VI,BilevelVariableInfo}
+    lower::Dict{VI,BilevelVariableInfo}
+    ldual::Dict{CI,BilevelConstraintInfo}
     # full map
-    map::Dict{VI, BilevelVariableInfo}
+    map::Dict{VI,BilevelVariableInfo}
     function ComplementBoundCache()
         return new(
-            Dict{VI, BilevelVariableInfo}(),
-            Dict{VI, BilevelVariableInfo}(),
-            Dict{CI, BilevelConstraintInfo}(),
-            Dict{VI, BilevelVariableInfo}(),
+            Dict{VI,BilevelVariableInfo}(),
+            Dict{VI,BilevelVariableInfo}(),
+            Dict{CI,BilevelConstraintInfo}(),
+            Dict{VI,BilevelVariableInfo}(),
         )
     end
 end
@@ -149,30 +142,28 @@ mutable struct FortunyAmatMcCarlMode{T} <: AbstractBilevelSolverMode{T}
     primal_big_M::Float64
     dual_big_M::Float64
     cache::ComplementBoundCache
-    function FortunyAmatMcCarlMode(;with_slack = false,
-        primal_big_M = Inf, dual_big_M = Inf)
-        return new{Float64}(
-            with_slack,
-            primal_big_M,
-            dual_big_M,
-            ComplementBoundCache()
-        )
+    function FortunyAmatMcCarlMode(;
+        with_slack = false,
+        primal_big_M = Inf,
+        dual_big_M = Inf,
+    )
+        return new{Float64}(with_slack, primal_big_M, dual_big_M, ComplementBoundCache())
     end
 end
 
 mutable struct MixedMode{T} <: AbstractBilevelSolverMode{T}
     default::AbstractBilevelSolverMode{T}
-    constraint_mode_map_c::Dict{CI, AbstractBilevelSolverMode{T}}
-    constraint_mode_map_v::Dict{VI, AbstractBilevelSolverMode{T}}
+    constraint_mode_map_c::Dict{CI,AbstractBilevelSolverMode{T}}
+    constraint_mode_map_v::Dict{VI,AbstractBilevelSolverMode{T}}
     cache::ComplementBoundCache
     function_cache::Dict{Int,MOI.AbstractScalarFunction}
-    function MixedMode(;default = SOS1Mode())
+    function MixedMode(; default = SOS1Mode())
         return new{Float64}(
             default,
-            Dict{CI, AbstractBilevelSolverMode{Float64}}(),
-            Dict{VI, AbstractBilevelSolverMode{Float64}}(),
+            Dict{CI,AbstractBilevelSolverMode{Float64}}(),
+            Dict{VI,AbstractBilevelSolverMode{Float64}}(),
             ComplementBoundCache(),
-            Dict{Int,MOI.AbstractScalarFunction}()
+            Dict{Int,MOI.AbstractScalarFunction}(),
         )
     end
 end
@@ -186,7 +177,7 @@ function reset!(mode::FortunyAmatMcCarlMode)
 end
 function reset!(mode::ProductMode)
     mode.function_cache = nothing
-    mode.comp_idx_in_sblm = Vector{CI}()
+    mode.comp_idx_in_sblm = CI[]
     return nothing
 end
 function reset!(mode::MixedMode)
@@ -210,32 +201,62 @@ function appush!(col, element)
     return nothing
 end
 
-function build_full_map!(mode,
-    upper_idxmap, lower_idxmap, lower_dual_idxmap, lower_primal_dual_map)
+function build_full_map!(
+    mode,
+    upper_idxmap,
+    lower_idxmap,
+    lower_dual_idxmap,
+    lower_primal_dual_map,
+)
     return nothing
 end
-function build_full_map!(mode::FortunyAmatMcCarlMode,
-        upper_idxmap, lower_idxmap, lower_dual_idxmap, lower_primal_dual_map)
-    _build_bound_map!(mode.cache,
-        upper_idxmap, lower_idxmap, lower_dual_idxmap, lower_primal_dual_map)
+function build_full_map!(
+    mode::FortunyAmatMcCarlMode,
+    upper_idxmap,
+    lower_idxmap,
+    lower_dual_idxmap,
+    lower_primal_dual_map,
+)
+    _build_bound_map!(
+        mode.cache,
+        upper_idxmap,
+        lower_idxmap,
+        lower_dual_idxmap,
+        lower_primal_dual_map,
+    )
     return nothing
 end
-function build_full_map!(mode::MixedMode,
-    upper_idxmap, lower_idxmap, lower_dual_idxmap, lower_primal_dual_map)
-_build_bound_map!(mode.cache,
-    upper_idxmap, lower_idxmap, lower_dual_idxmap, lower_primal_dual_map)
-return nothing
+function build_full_map!(
+    mode::MixedMode,
+    upper_idxmap,
+    lower_idxmap,
+    lower_dual_idxmap,
+    lower_primal_dual_map,
+)
+    _build_bound_map!(
+        mode.cache,
+        upper_idxmap,
+        lower_idxmap,
+        lower_dual_idxmap,
+        lower_primal_dual_map,
+    )
+    return nothing
 end
-function _build_bound_map!(mode::ComplementBoundCache,
-    upper_idxmap, lower_idxmap, lower_dual_idxmap, lower_primal_dual_map)
+function _build_bound_map!(
+    mode::ComplementBoundCache,
+    upper_idxmap,
+    lower_idxmap,
+    lower_dual_idxmap,
+    lower_primal_dual_map,
+)
     empty!(mode.map)
-    for (k,v) in mode.upper
+    for (k, v) in mode.upper
         mode.map[upper_idxmap[k]] = v
     end
-    for (k,v) in mode.lower
+    for (k, v) in mode.lower
         mode.map[lower_idxmap[k]] = v
     end
-    for (k,v) in mode.ldual
+    for (k, v) in mode.ldual
         vec = lower_primal_dual_map.primal_con_dual_var[k]#[1] # TODO check this scalar
         for var in vec
             mode.map[lower_dual_idxmap[var]] = BilevelVariableInfo(v)
@@ -247,22 +268,24 @@ end
 mutable struct StrongDualityMode{T} <: AbstractBilevelSolverMode{T}
     inequality::Bool
     epsilon::T
-    function StrongDualityMode(eps::T=zero(Float64); inequality = true) where T
+    function StrongDualityMode(eps::T = zero(Float64); inequality = true) where {T}
         return new{T}(inequality, eps)
     end
 end
 
-ignore_dual_objective(::AbstractBilevelSolverMode{T}) where T = true
-ignore_dual_objective(::StrongDualityMode{T}) where T = false
+ignore_dual_objective(::AbstractBilevelSolverMode{T}) where {T} = true
+ignore_dual_objective(::StrongDualityMode{T}) where {T} = false
 
-function accept_vector_set(mode::AbstractBilevelSolverMode{T}, con::Complement) where T
+function accept_vector_set(mode::AbstractBilevelSolverMode{T}, con::Complement) where {T}
     if con.is_vec
-        error("Set $(typeof(con.set_w_zero)) is not accepted when solution method is $(typeof(mode))")
+        error(
+            "Set $(typeof(con.set_w_zero)) is not accepted when solution method is $(typeof(mode))",
+        )
     end
     return nothing
 end
-accept_vector_set(::ProductMode{T}, ::Complement) where T = nothing
-accept_vector_set(::MixedMode{T}, ::Complement) where T = nothing
+accept_vector_set(::ProductMode{T}, ::Complement) where {T} = nothing
+accept_vector_set(::MixedMode{T}, ::Complement) where {T} = nothing
 
 function get_canonical_complements(primal_model, primal_dual_map)
     map = primal_dual_map.primal_con_dual_var
@@ -273,8 +296,7 @@ function get_canonical_complements(primal_model, primal_dual_map)
     end
     return out
 end
-function get_canonical_complement(primal_model, map,
-    ci::CI{F,S}) where {F, S<:VECTOR_SETS}
+function get_canonical_complement(primal_model, map, ci::CI{F,S}) where {F,S<:VECTOR_SETS}
     T = Float64
     func = MOI.copy(MOI.get(primal_model, MOI.ConstraintFunction(), ci))::F
     set = MOI.copy(MOI.get(primal_model, MOI.ConstraintSet(), ci))::S
@@ -288,13 +310,12 @@ function get_canonical_complement(primal_model, map,
     con = Complement(true, ci, func, set_with_zero(set), map[ci])
     return con
 end
-function get_canonical_complement(primal_model, map,
-    ci::CI{F,S}) where {F, S<:SCALAR_SETS}
+function get_canonical_complement(primal_model, map, ci::CI{F,S}) where {F,S<:SCALAR_SETS}
     T = Float64
     func = MOI.copy(MOI.get(primal_model, MOI.ConstraintFunction(), ci))::F
     set = MOI.copy(MOI.get(primal_model, MOI.ConstraintSet(), ci))::S
-    constant = Dualization.set_dot(1, set, T) *
-        Dualization.get_scalar_term(primal_model, ci)[]
+    constant =
+        Dualization.set_dot(1, set, T) * Dualization.get_scalar_term(primal_model, ci)[]
     if F == MOI.VariableIndex
         func = MOIU.operate(+, T, func, constant)
     else
@@ -320,8 +341,8 @@ function build_bilevel(
     mode,
     upper_var_to_lower_ctr::Dict{VI,CI} = Dict{VI,CI}();
     copy_names::Bool = false,
-    pass_start::Bool = false
-    )
+    pass_start::Bool = false,
+)
 
     # Start with an empty problem
     moi_mode = MOIU.AUTOMATIC
@@ -331,8 +352,9 @@ function build_bilevel(
         Create Lower DUAL level model
     =#
     # dualize the second level
-    dual_problem = Dualization.dualize(lower,
-        dual_names = DualNames("dual_","dual_"),
+    dual_problem = Dualization.dualize(
+        lower,
+        dual_names = DualNames("dual_", "dual_"),
         variable_parameters = upper_variables,
         ignore_objective = ignore_dual_objective(mode),
         consider_constrained_variables = false,
@@ -398,11 +420,13 @@ function build_bilevel(
     lower_dual_idxmap = MOIU.IndexMap()
     # 1) for QP's there are dual variable that are linked to:
     # 1.1) primal variables
-    for (lower_primal_var_key, lower_dual_quad_slack_val) in lower_primal_dual_map.primal_var_dual_quad_slack
+    for (lower_primal_var_key, lower_dual_quad_slack_val) in
+        lower_primal_dual_map.primal_var_dual_quad_slack
         lower_dual_idxmap[lower_dual_quad_slack_val] = lower_idxmap[lower_primal_var_key]
     end
     # 1.2) and to upper level variable which are lower level parameters
-    for (lower_primal_param_key, lower_dual_param_val) in lower_primal_dual_map.primal_parameter
+    for (lower_primal_param_key, lower_dual_param_val) in
+        lower_primal_dual_map.primal_parameter
         lower_dual_idxmap[lower_dual_param_val] = lower_idxmap[lower_primal_param_key]
     end
     # 2) Dual variables might appear in the upper level
@@ -422,8 +446,13 @@ function build_bilevel(
     =#
 
     # build map bound map for FortunyAmatMcCarlMode
-    build_full_map!(mode,
-        upper_idxmap, lower_idxmap, lower_dual_idxmap, lower_primal_dual_map)
+    build_full_map!(
+        mode,
+        upper_idxmap,
+        lower_idxmap,
+        lower_dual_idxmap,
+        lower_primal_dual_map,
+    )
 
     if ignore_dual_objective(mode)
         # complementary slackness
@@ -431,25 +460,45 @@ function build_bilevel(
         for comp in comps
             if !is_equality(comp.set_w_zero)
                 accept_vector_set(mode, comp)
-                add_complement(mode, m, comp,
-                    lower_idxmap, lower_dual_idxmap, copy_names, pass_start)
+                add_complement(
+                    mode,
+                    m,
+                    comp,
+                    lower_idxmap,
+                    lower_dual_idxmap,
+                    copy_names,
+                    pass_start,
+                )
             else
                 # feasible equality constraints always satisfy complementarity
             end
         end
     else # strong duality
-        add_strong_duality(mode, m, lower_primal_obj, lower_dual_obj, lower_idxmap, lower_dual_idxmap)
+        add_strong_duality(
+            mode,
+            m,
+            lower_primal_obj,
+            lower_dual_obj,
+            lower_idxmap,
+            lower_dual_idxmap,
+        )
     end
     add_aggregate_constraints(m, mode, copy_names)
 
     return m, upper_idxmap, lower_idxmap, lower_primal_dual_map, lower_dual_idxmap
 end
 
-function add_strong_duality(mode::StrongDualityMode{T}, m, primal_obj, dual_obj,
-    idxmap_primal, idxmap_dual) where T
+function add_strong_duality(
+    mode::StrongDualityMode{T},
+    m,
+    primal_obj,
+    dual_obj,
+    idxmap_primal,
+    idxmap_dual,
+) where {T}
 
     primal = MOIU.map_indices.(Ref(idxmap_primal), primal_obj)
-    dual   = MOIU.map_indices.(Ref(idxmap_dual), dual_obj)
+    dual = MOIU.map_indices.(Ref(idxmap_dual), dual_obj)
 
     func = MOIU.operate(-, T, primal, dual)
 
@@ -473,18 +522,18 @@ end
 add_aggregate_constraints(m, mode, copy_names) = nothing
 
 function _add_aggregate_constraints(
-    m, func::F, eps, idx, copy_names
-) where F<:MOI.ScalarQuadraticFunction{T} where T
+    m,
+    func::F,
+    eps,
+    idx,
+    copy_names,
+) where {F<:MOI.ScalarQuadraticFunction{T}} where {T}
     prod_f1 = MOIU.operate(-, T, func, eps)
-    c1 = MOIU.normalize_and_add_constraint(m,
-        prod_f1,
-        MOI.LessThan{T}(0.0))
+    c1 = MOIU.normalize_and_add_constraint(m, prod_f1, MOI.LessThan{T}(0.0))
     # appush!(out_ctr, c1)
     if true # comp.is_vec
         prod_f2 = MOIU.operate(+, T, func, eps)
-        c2 = MOIU.normalize_and_add_constraint(m,
-            prod_f2,
-            MOI.GreaterThan{T}(0.0))
+        c2 = MOIU.normalize_and_add_constraint(m, prod_f2, MOI.GreaterThan{T}(0.0))
         # appush!(out_ctr, c2)
     end
     if copy_names
@@ -499,19 +548,18 @@ function add_aggregate_constraints(m, mode::ProductMode, copy_names)
     if mode.function_cache === nothing
         return nothing
     end
-    _add_aggregate_constraints(
-        m, mode.function_cache, mode.epsilon, 0, copy_names)
+    _add_aggregate_constraints(m, mode.function_cache, mode.epsilon, 0, copy_names)
     return nothing
 end
-function add_aggregate_constraints(m, mode::MixedMode{T}, copy_names) where T
+function add_aggregate_constraints(m, mode::MixedMode{T}, copy_names) where {T}
     if isempty(mode.function_cache)
         return nothing
     end
-    eps = Dict{Int, T}()
+    eps = Dict{Int,T}()
     for list in (
         mode.constraint_mode_map_c,
         mode.constraint_mode_map_v,
-        Dict(nothing=>mode.default)
+        Dict(nothing => mode.default),
     )
         for md in values(list)
             val, idx = _get_eps_idx(md)
@@ -523,13 +571,12 @@ function add_aggregate_constraints(m, mode::MixedMode{T}, copy_names) where T
         end
     end
     for (idx, func) in mode.function_cache
-        _add_aggregate_constraints(
-            m, func, eps[idx], idx, copy_names)
+        _add_aggregate_constraints(m, func, eps[idx], idx, copy_names)
     end
     return nothing
 end
 
-function _get_eps_idx(mode::ProductMode{T}) where T
+function _get_eps_idx(mode::ProductMode{T}) where {T}
     idx = mode.aggregation_group
     eps = mode.epsilon
     return eps, idx
@@ -538,22 +585,28 @@ function _get_eps_idx(mode)
     return 0.0, 0
 end
 
-function add_complement(mode::MixedMode{T}, m, comp::Complement,
-        idxmap_primal, idxmap_dual, copy_names::Bool, pass_start::Bool) where T
+function add_complement(
+    mode::MixedMode{T},
+    m,
+    comp::Complement,
+    idxmap_primal,
+    idxmap_dual,
+    copy_names::Bool,
+    pass_start::Bool,
+) where {T}
     _mode = get_mode(mode, comp.constraint, idxmap_primal)
     accept_vector_set(_mode, comp)
-    ret = add_complement(_mode, m, comp,
-        idxmap_primal, idxmap_dual, copy_names, pass_start)
+    ret = add_complement(_mode, m, comp, idxmap_primal, idxmap_dual, copy_names, pass_start)
     add_function_to_cache(mode, _mode)
     return ret
 end
-add_function_to_cache(mode::MixedMode{T}, _mode) where T = nothing
-function add_function_to_cache(mode::MixedMode{T}, _mode::ProductMode{T}) where T
+add_function_to_cache(mode::MixedMode{T}, _mode) where {T} = nothing
+function add_function_to_cache(mode::MixedMode{T}, _mode::ProductMode{T}) where {T}
     idx = _mode.aggregation_group
     if _mode.function_cache !== nothing && idx > 0
         if haskey(mode.function_cache, idx)
-            mode.function_cache[idx] = MOIU.operate(+, T,
-                mode.function_cache[idx], _mode.function_cache)
+            mode.function_cache[idx] =
+                MOIU.operate(+, T, mode.function_cache[idx], _mode.function_cache)
         else
             mode.function_cache[idx] = _mode.function_cache
         end
@@ -562,11 +615,11 @@ function add_function_to_cache(mode::MixedMode{T}, _mode::ProductMode{T}) where 
     return nothing
 end
 
-function get_mode(mode::MixedMode{T}, ci::CI{F,S}, map) where {
-    T,
-    F<:MOI.VariableIndex,
-    S<:Union{MOI.EqualTo{T}, MOI.LessThan{T}, MOI.GreaterThan{T}}
-}
+function get_mode(
+    mode::MixedMode{T},
+    ci::CI{F,S},
+    map,
+) where {T,F<:MOI.VariableIndex,S<:Union{MOI.EqualTo{T},MOI.LessThan{T},MOI.GreaterThan{T}}}
     # key = map[VI(ci.value)]
     key = VI(ci.value)
     if haskey(mode.constraint_mode_map_v, key)
@@ -584,8 +637,15 @@ function get_mode(mode::MixedMode{T}, ci::CI{F,S}, map) where {T,F,S}
     end
 end
 
-function add_complement(mode::ComplementMode{T}, m, comp::Complement,
-    idxmap_primal, idxmap_dual, copy_names, pass_start::Bool) where T
+function add_complement(
+    mode::ComplementMode{T},
+    m,
+    comp::Complement,
+    idxmap_primal,
+    idxmap_dual,
+    copy_names,
+    pass_start::Bool,
+) where {T}
     f = comp.func_w_cte
     s = comp.set_w_zero
     v = comp.variable
@@ -605,15 +665,15 @@ function add_complement(mode::ComplementMode{T}, m, comp::Complement,
 
         if pass_start
             val = MOIU.eval_variables(
-                x-> nothing_to_nan(MOI.get(m, MOI.VariablePrimalStart(), x)), f_dest)
+                x -> nothing_to_nan(MOI.get(m, MOI.VariablePrimalStart(), x)),
+                f_dest,
+            )
             if !isnan(val)
                 MOI.set(m, MOI.VariablePrimalStart(), slack, val)
             end
         end
 
-        c = MOI.add_constraint(m, 
-            MOI.VectorOfVariables([slack, dual]),
-            MOI.Complements(1))
+        c = MOI.add_constraint(m, MOI.VectorOfVariables([slack, dual]), MOI.Complements(1))
         if copy_names
             nm = MOI.get(m, MOI.VariableName(), dual)
             MOI.set(m, MOI.VariableName(), slack, "slk_($(nm))")
@@ -629,9 +689,7 @@ function add_complement(mode::ComplementMode{T}, m, comp::Complement,
     else
         new_f = MOIU.operate(vcat, T, f_dest, dual)
 
-        c = MOI.add_constraint(m, 
-            new_f,
-            MOI.Complements(1))
+        c = MOI.add_constraint(m, new_f, MOI.Complements(1))
 
         if copy_names
             nm = MOI.get(m, MOI.VariableName(), dual)
@@ -644,8 +702,15 @@ function add_complement(mode::ComplementMode{T}, m, comp::Complement,
     return out_var, out_ctr
 end
 
-function add_complement(mode::SOS1Mode{T}, m, comp::Complement,
-    idxmap_primal, idxmap_dual, copy_names::Bool, pass_start::Bool) where T
+function add_complement(
+    mode::SOS1Mode{T},
+    m,
+    comp::Complement,
+    idxmap_primal,
+    idxmap_dual,
+    copy_names::Bool,
+    pass_start::Bool,
+) where {T}
     f = comp.func_w_cte
     s = comp.set_w_zero
     v = comp.variable
@@ -660,9 +725,7 @@ function add_complement(mode::SOS1Mode{T}, m, comp::Complement,
     equality = MOIU.normalize_and_add_constraint(m, new_f, MOI.EqualTo(zero(T)))
 
     dual = idxmap_dual[v]
-    c1 = MOI.add_constraint(m, 
-        MOI.VectorOfVariables([slack, dual]),
-        MOI.SOS1([1.0, 2.0]))
+    c1 = MOI.add_constraint(m, MOI.VectorOfVariables([slack, dual]), MOI.SOS1([1.0, 2.0]))
 
     if copy_names
         nm = MOI.get(m, MOI.VariableName(), dual)
@@ -676,7 +739,7 @@ function add_complement(mode::SOS1Mode{T}, m, comp::Complement,
 end
 
 is_equality(set::S) where {S<:MOI.AbstractSet} = false
-is_equality(set::MOI.EqualTo{T}) where T = true
+is_equality(set::MOI.EqualTo{T}) where {T} = true
 is_equality(set::MOI.Zeros) = true
 
 only_variable_functions(v::MOI.VariableIndex) = v
@@ -693,8 +756,15 @@ function add_function_to_cache(mode::ProductMode{T}, func) where {T}
     end
     return nothing
 end
-function add_complement(mode::ProductMode{T}, m, comp::Complement,
-    idxmap_primal, idxmap_dual, copy_names::Bool, pass_start::Bool) where T
+function add_complement(
+    mode::ProductMode{T},
+    m,
+    comp::Complement,
+    idxmap_primal,
+    idxmap_dual,
+    copy_names::Bool,
+    pass_start::Bool,
+) where {T}
     f = comp.func_w_cte
     s = comp.set_w_zero
     v = comp.variable
@@ -705,9 +775,9 @@ function add_complement(mode::ProductMode{T}, m, comp::Complement,
     eps = mode.epsilon
     with_slack = mode.with_slack
 
-    f_dest = MOIU.map_indices(x->idxmap_primal[x], f)
+    f_dest = MOIU.map_indices(x -> idxmap_primal[x], f)
 
-    dual = comp.is_vec ? map(x->idxmap_dual[x], v) : idxmap_dual[v]
+    dual = comp.is_vec ? map(x -> idxmap_dual[x], v) : idxmap_dual[v]
 
     if with_slack
         slack, slack_in_set = if comp.is_vec
@@ -722,7 +792,12 @@ function add_complement(mode::ProductMode{T}, m, comp::Complement,
             equality = MOIU.normalize_and_add_constraint(m, new_f, MOI.EqualTo(zero(T)))
         end
 
-        prod_f = MOIU.operate(dot, T, only_variable_functions(slack), only_variable_functions(dual))
+        prod_f = MOIU.operate(
+            dot,
+            T,
+            only_variable_functions(slack),
+            only_variable_functions(dual),
+        )
 
         appush!(out_var, slack)
         appush!(out_ctr, slack_in_set)
@@ -730,15 +805,15 @@ function add_complement(mode::ProductMode{T}, m, comp::Complement,
 
         if mode.aggregation_group == 0
             prod_f1 = MOIU.operate(-, T, prod_f, eps)
-            c1 = MOIU.normalize_and_add_constraint(m,
-                prod_f1,
-                MOI.LessThan{Float64}(0.0))
+            c1 = MOIU.normalize_and_add_constraint(m, prod_f1, MOI.LessThan{Float64}(0.0))
             appush!(out_ctr, c1)
             if comp.is_vec
                 prod_f2 = MOIU.operate(+, T, prod_f, eps)
-                c2 = MOIU.normalize_and_add_constraint(m,
+                c2 = MOIU.normalize_and_add_constraint(
+                    m,
                     prod_f2,
-                    MOI.GreaterThan{Float64}(0.0))
+                    MOI.GreaterThan{Float64}(0.0),
+                )
                 appush!(out_ctr, c2)
             end
         else
@@ -747,7 +822,9 @@ function add_complement(mode::ProductMode{T}, m, comp::Complement,
 
         if pass_start
             val = MOIU.eval_variables(
-                x-> nothing_to_nan(MOI.get(m, MOI.VariablePrimalStart(), x)), f_dest)
+                x -> nothing_to_nan(MOI.get(m, MOI.VariablePrimalStart(), x)),
+                f_dest,
+            )
             if comp.is_vec
                 for i in eachindex(val)
                     if !isnan(val[i])
@@ -777,15 +854,11 @@ function add_complement(mode::ProductMode{T}, m, comp::Complement,
         new_f = MOIU.operate(dot, T, f_dest, only_variable_functions(dual))
         if mode.aggregation_group == 0
             new_f1 = MOIU.operate(-, T, new_f, eps)
-            c1 = MOIU.normalize_and_add_constraint(m, 
-                new_f1,
-                MOI.LessThan{T}(0.0))
+            c1 = MOIU.normalize_and_add_constraint(m, new_f1, MOI.LessThan{T}(0.0))
             appush!(out_ctr, c1)
             if comp.is_vec # conic
                 new_f2 = MOIU.operate(+, T, new_f, eps)
-                c2 = MOIU.normalize_and_add_constraint(m, 
-                    new_f2,
-                    MOI.GreaterThan{T}(0.0))
+                c2 = MOIU.normalize_and_add_constraint(m, new_f2, MOI.GreaterThan{T}(0.0))
                 appush!(out_ctr, c2)
             end
             if copy_names
@@ -803,12 +876,19 @@ function add_complement(mode::ProductMode{T}, m, comp::Complement,
             add_function_to_cache(mode, new_f)
         end
     end
-    appush!(mode.comp_idx_in_sblm,out_ctr)
+    appush!(mode.comp_idx_in_sblm, out_ctr)
     return out_var, out_ctr
 end
 
-function add_complement(mode::IndicatorMode{T}, m, comp::Complement,
-    idxmap_primal, idxmap_dual, copy_names::Bool, pass_start::Bool) where T
+function add_complement(
+    mode::IndicatorMode{T},
+    m,
+    comp::Complement,
+    idxmap_primal,
+    idxmap_dual,
+    copy_names::Bool,
+    pass_start::Bool,
+) where {T}
     f = comp.func_w_cte
     s = comp.set_w_zero
     v = comp.variable
@@ -818,7 +898,7 @@ function add_complement(mode::IndicatorMode{T}, m, comp::Complement,
     is_tight = false
     has_start = false
 
-    f_dest = MOIU.map_indices(x->idxmap_primal[x], f)
+    f_dest = MOIU.map_indices(x -> idxmap_primal[x], f)
 
     dual = idxmap_dual[v]
 
@@ -864,7 +944,9 @@ function add_complement(mode::IndicatorMode{T}, m, comp::Complement,
 
     if pass_start
         val = MOIU.eval_variables(
-            x-> nothing_to_nan(MOI.get(m, MOI.VariablePrimalStart(), x)), f_dest)
+            x -> nothing_to_nan(MOI.get(m, MOI.VariablePrimalStart(), x)),
+            f_dest,
+        )
         if !isnan(val)
             is_tight = abs(val) < 1e-8
             has_start = true
@@ -904,10 +986,10 @@ function add_complement(mode::IndicatorMode{T}, m, comp::Complement,
     return c1
 end
 
-function flip_set(set::MOI.LessThan{T}) where T
+function flip_set(set::MOI.LessThan{T}) where {T}
     return MOI.GreaterThan{T}(0.0)
 end
-function flip_set(set::MOI.GreaterThan{T}) where T
+function flip_set(set::MOI.GreaterThan{T}) where {T}
     return MOI.LessThan{T}(0.0)
 end
 
@@ -925,15 +1007,22 @@ function get_bounds(var, map, fallback_bound = Inf)
     end
 end
 
-function set_bound(inter::Interval, ::LT{T}) where T
+function set_bound(inter::Interval, ::LT{T}) where {T}
     return inter.hi
 end
-function set_bound(inter::Interval, ::GT{T}) where T
+function set_bound(inter::Interval, ::GT{T}) where {T}
     return inter.lo
 end
 
-function add_complement(mode::FortunyAmatMcCarlMode{T}, m, comp::Complement,
-    idxmap_primal, idxmap_dual, copy_names::Bool, pass_start::Bool) where T
+function add_complement(
+    mode::FortunyAmatMcCarlMode{T},
+    m,
+    comp::Complement,
+    idxmap_primal,
+    idxmap_dual,
+    copy_names::Bool,
+    pass_start::Bool,
+) where {T}
 
     f = comp.func_w_cte
     s = comp.set_w_zero
@@ -947,11 +1036,14 @@ function add_complement(mode::FortunyAmatMcCarlMode{T}, m, comp::Complement,
     end
     f_dest = MOIU.map_indices.(Ref(idxmap_primal), f)
 
-    f_bounds = MOIU.eval_variables(vi -> get_bounds(vi, mode.cache.map, mode.primal_big_M), f_dest)
+    f_bounds =
+        MOIU.eval_variables(vi -> get_bounds(vi, mode.cache.map, mode.primal_big_M), f_dest)
 
     if pass_start
         val = MOIU.eval_variables(
-            x-> nothing_to_nan(MOI.get(m, MOI.VariablePrimalStart(), x)), f_dest)
+            x -> nothing_to_nan(MOI.get(m, MOI.VariablePrimalStart(), x)),
+            f_dest,
+        )
         if !isnan(val)
             is_tight = abs(val) < 1e-8
             has_start = true
@@ -984,17 +1076,17 @@ function add_complement(mode::FortunyAmatMcCarlMode{T}, m, comp::Complement,
     Mv = set_bound(v_bounds, s2)
 
     if isnan(Ms) || abs(Ms) >= Inf || isnan(Mv) || abs(Mv) >= Inf
-        error("It was not possible to automatically compute bounds"*
-            " for a complementarity pair, please add the arguments"*
-            " primal_big_M and dual_big_M to FortunyAmatMcCarlMode")
+        error(
+            "It was not possible to automatically compute bounds" *
+            " for a complementarity pair, please add the arguments" *
+            " primal_big_M and dual_big_M to FortunyAmatMcCarlMode",
+        )
     end
-    
+
     if mode.with_slack
         f1 = MOI.ScalarAffineFunction{T}(
-            MOI.ScalarAffineTerm{T}.(
-                [one(T), -Ms], [slack, bin]
-            ),
-            0.0
+            MOI.ScalarAffineTerm{T}.([one(T), -Ms], [slack, bin]),
+            0.0,
         )
     else
         push!(f_dest.terms, MOI.ScalarAffineTerm{T}(-Ms, bin))
@@ -1002,10 +1094,8 @@ function add_complement(mode::FortunyAmatMcCarlMode{T}, m, comp::Complement,
     end
 
     f2 = MOI.ScalarAffineFunction{T}(
-        MOI.ScalarAffineTerm{T}.(
-            [one(T), Mv], [dual, bin]
-        ),
-        -Mv
+        MOI.ScalarAffineTerm{T}.([one(T), Mv], [dual, bin]),
+        -Mv,
     )
 
     c1 = MOIU.normalize_and_add_constraint(m, f1, s2)
@@ -1032,7 +1122,7 @@ function add_complement(mode::FortunyAmatMcCarlMode{T}, m, comp::Complement,
     return c1
 end
 
-function to_vector_affine(f::MOI.VectorAffineFunction{T}) where T
+function to_vector_affine(f::MOI.VectorAffineFunction{T}) where {T}
     return f
 end
 function to_vector_affine(f::MOI.VectorOfVariables)
@@ -1042,9 +1132,13 @@ end
 function handle_lower_objective_sense(lower::MOI.ModelLike)
     lower_objective_sense = MOI.get(lower, MOI.ObjectiveSense())
     if lower_objective_sense == MOI.FEASIBILITY_SENSE
-        throw(ErrorException("Lower level models with objective_sense: " * 
-                            lower_objective_sense * 
-                            " are not supported."))
+        throw(
+            ErrorException(
+                "Lower level models with objective_sense: " *
+                lower_objective_sense *
+                " are not supported.",
+            ),
+        )
     end
     return
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -9,6 +9,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
-Ipopt = "=1.0.2"
+Ipopt = "=1.1.0"
 MibS_jll = "=1.1.3"
 QuadraticToBinary = "=0.4.0"

--- a/test/iterative_product_mode.jl
+++ b/test/iterative_product_mode.jl
@@ -48,7 +48,7 @@ function iterative_product_mode_01()
 
 end
 
-function iterative_product_mode_02_1()
+function iterative_product_mode_02_1_min()
     # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
     # It can be found in section 3 "Numerical Examples"
     # Dataset 1
@@ -98,12 +98,12 @@ function iterative_product_mode_02_1()
 
     optimize!(model1; show_iter_log = false)
 
-    @test isapprox(value(model1[:Q]), 6; atol = 1e-6)
-    @test isapprox(value.(model1[:q]).data, [2, 2]; atol = 1e-6)
+    @test isapprox(value(model1[:Q]), 6; atol = 1e-4)
+    @test isapprox(value.(model1[:q]).data, [2, 2]; atol = 1e-4)
 
 end
 
-function iterative_product_mode_02_2()
+function iterative_product_mode_02_2_min()
     # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics" 
     # It can be found in section 3 "Numerical Examples"
     # Dataset 2: 
@@ -153,12 +153,12 @@ function iterative_product_mode_02_2()
 
     # Auto testing
 
-    @test isapprox(value(model2[:Q]), 60; atol = 1e-6)
-    @test isapprox(value.(model2[:q]).data, [20, 20]; atol = 1e-6)
+    @test isapprox(value(model2[:Q]), 60; atol = 1e-4)
+    @test isapprox(value.(model2[:q]).data, [20, 20]; atol = 1e-4)
 
 end
 
-function iterative_product_mode_02_3()
+function iterative_product_mode_02_3_min()
     # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
     # It can be found in section 3 "Numerical Examples"
     # Dataset 3:
@@ -208,7 +208,172 @@ function iterative_product_mode_02_3()
 
     # Auto testing
 
-    @test isapprox(value(model3[:Q]), 55; atol = 1e-6)
+    @test isapprox(value(model3[:Q]), 55; atol = 1e-4)
+    @test isapprox(value.(model3[:q]).data, [18.333, 18.333]; atol = 1e-2)
+
+end
+
+function iterative_product_mode_02_1_max()
+    # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
+    # It can be found in section 3 "Numerical Examples"
+    # Dataset 1
+
+    F = [1, 2]
+    c = Dict(1 => 1, 2 => 1)
+    C = 1
+    a = 13
+    b = 1
+
+    iter_eps = [1e-0 * 0.95^i for i = 1:300]
+
+    iter_attr = Dict(
+        "mu_init" => 1e-9,
+        "warm_start_init_point" => "yes",
+        "warm_start_bound_push" => 1e-12,
+        "warm_start_bound_frac" => 1e-12,
+        "warm_start_slack_bound_frac" => 1e-12,
+        "warm_start_slack_bound_push" => 1e-12,
+        "warm_start_mult_bound_push" => 1e-12,
+        # "output_file" => "solver.log",
+        # "file_print_level" => 8,
+        "print_level" => 0,
+    )
+
+    model1 = BilevelModel(
+        Ipopt.Optimizer,
+        mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+    )
+    set_optimizer_attribute(model1, "print_level", 0)
+
+    @variable(Lower(model1), q[F] >= 0)
+    @variable(Upper(model1), Q >= 0)
+
+    @objective(Upper(model1), Max, ((a - b * (q[1] + q[2] + Q)) * Q - C * Q))
+
+    @objective(
+        Lower(model1),
+        Max,
+        (
+            (a - b * (q[1] + q[2] + Q)) * q[1] - C * q[1] +
+            (a - b * (q[1] + q[2] + Q)) * q[2] - C * q[2] + b * q[1] * q[2]
+        )
+    )
+
+    set_optimizer_attribute(model1, "mu_target", 1e-9)
+
+    optimize!(model1; show_iter_log = false)
+
+    @test isapprox(value(model1[:Q]), 6; atol = 1e-4)
+    @test isapprox(value.(model1[:q]).data, [2, 2]; atol = 1e-4)
+
+end
+
+function iterative_product_mode_02_2_max()
+    # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics" 
+    # It can be found in section 3 "Numerical Examples"
+    # Dataset 2: 
+
+    F = [1, 2]
+    c = Dict(1 => 1, 2 => 1)
+    C = 1
+    a = 13
+    b = 0.1
+
+    iter_eps = [1e-0 * 0.95^i for i = 1:300]
+
+    iter_attr = Dict(
+        "mu_init" => 1e-9,
+        "warm_start_init_point" => "yes",
+        "warm_start_bound_push" => 1e-12,
+        "warm_start_bound_frac" => 1e-12,
+        "warm_start_slack_bound_frac" => 1e-12,
+        "warm_start_slack_bound_push" => 1e-12,
+        "warm_start_mult_bound_push" => 1e-12,
+        "print_level" => 0,
+    )
+
+    model2 = BilevelModel(
+        Ipopt.Optimizer,
+        mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+    )
+    set_optimizer_attribute(model2, "print_level", 0)
+
+    @variable(Lower(model2), q[F] >= 0)
+    @variable(Upper(model2), Q >= 0)
+
+    @objective(Upper(model2), Max, ((a - b * (q[1] + q[2] + Q)) * Q - C * Q))
+
+    @objective(
+        Lower(model2),
+        Max,
+        (
+            (a - b * (q[1] + q[2] + Q)) * q[1] - C * q[1] +
+            (a - b * (q[1] + q[2] + Q)) * q[2] - C * q[2] + b * q[1] * q[2]
+        )
+    )
+
+    set_optimizer_attribute(model2, "mu_target", 1e-9)
+
+    optimize!(model2; show_iter_log = false)
+
+    # Auto testing
+
+    @test isapprox(value(model2[:Q]), 60; atol = 1e-4)
+    @test isapprox(value.(model2[:q]).data, [20, 20]; atol = 1e-4)
+
+end
+
+function iterative_product_mode_02_3_max()
+    # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
+    # It can be found in section 3 "Numerical Examples"
+    # Dataset 3:
+
+    F = [1, 2]
+    c = Dict(1 => 1, 2 => 1)
+    C = 2
+    a = 13
+    b = 0.1
+
+    iter_eps = [1e-0 * 0.95^i for i = 1:300]
+
+    iter_attr = Dict(
+        "mu_init" => 1e-9,
+        "warm_start_init_point" => "yes",
+        "warm_start_bound_push" => 1e-12,
+        "warm_start_bound_frac" => 1e-12,
+        "warm_start_slack_bound_frac" => 1e-12,
+        "warm_start_slack_bound_push" => 1e-12,
+        "warm_start_mult_bound_push" => 1e-12,
+        "print_level" => 0,
+    )
+
+    model3 = BilevelModel(
+        Ipopt.Optimizer,
+        mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+    )
+    set_optimizer_attribute(model3, "print_level", 0)
+
+    @variable(Lower(model3), q[F] >= 0)
+    @variable(Upper(model3), Q >= 0)
+
+    @objective(Upper(model3), Max, ((a - b * (q[1] + q[2] + Q)) * Q - C * Q))
+
+    @objective(
+        Lower(model3),
+        Max,
+        (
+            (a - b * (q[1] + q[2] + Q)) * q[1] - C * q[1] +
+            (a - b * (q[1] + q[2] + Q)) * q[2] - C * q[2] + b * q[1] * q[2]
+        )
+    )
+
+    set_optimizer_attribute(model3, "mu_target", 1e-9)
+
+    optimize!(model3; show_iter_log = false)
+
+    # Auto testing
+
+    @test isapprox(value(model3[:Q]), 55; atol = 1e-4)
     @test isapprox(value.(model3[:q]).data, [18.333, 18.333]; atol = 1e-2)
 
 end

--- a/test/iterative_product_mode.jl
+++ b/test/iterative_product_mode.jl
@@ -1,4 +1,4 @@
-function iterative_product_mode_01()
+function iterative_product_mode_01(consider_variable_bounds::Bool)
     # This example is from the book Decomposition Techniques in Mathematical Programming, as used in the examples section
     # Chapter 7.2, page 281, [url](https://www.springer.com/gp/book/9783540276852)
     iter_eps = [1e-0 * 0.95^i for i = 1:300]
@@ -39,7 +39,7 @@ function iterative_product_mode_01()
 
     set_optimizer_attribute(model, "mu_target", 1e-9)
 
-    optimize!(model; show_iter_log = false)
+    optimize!(model; show_iter_log = false, consider_constrained_variables = consider_variable_bounds)
 
     @test value(x) ≈ 1 atol = 1e-4
     @test value(y) ≈ 6 atol = 1e-4
@@ -48,7 +48,7 @@ function iterative_product_mode_01()
 
 end
 
-function iterative_product_mode_02_1_min()
+function iterative_product_mode_02_1_min(consider_variable_bounds::Bool)
     # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
     # It can be found in section 3 "Numerical Examples"
     # Dataset 1
@@ -96,14 +96,14 @@ function iterative_product_mode_02_1_min()
 
     set_optimizer_attribute(model1, "mu_target", 1e-9)
 
-    optimize!(model1; show_iter_log = false)
+    optimize!(model1; show_iter_log = false, consider_constrained_variables = consider_variable_bounds)
 
     @test isapprox(value(model1[:Q]), 6; atol = 1e-4)
     @test isapprox(value.(model1[:q]).data, [2, 2]; atol = 1e-4)
 
 end
 
-function iterative_product_mode_02_2_min()
+function iterative_product_mode_02_2_min(consider_variable_bounds::Bool)
     # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics" 
     # It can be found in section 3 "Numerical Examples"
     # Dataset 2: 
@@ -149,7 +149,7 @@ function iterative_product_mode_02_2_min()
 
     set_optimizer_attribute(model2, "mu_target", 1e-9)
 
-    optimize!(model2; show_iter_log = false)
+    optimize!(model2; show_iter_log = false, consider_constrained_variables = consider_variable_bounds)
 
     # Auto testing
 
@@ -158,7 +158,7 @@ function iterative_product_mode_02_2_min()
 
 end
 
-function iterative_product_mode_02_3_min()
+function iterative_product_mode_02_3_min(consider_variable_bounds::Bool)
     # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
     # It can be found in section 3 "Numerical Examples"
     # Dataset 3:
@@ -204,7 +204,7 @@ function iterative_product_mode_02_3_min()
 
     set_optimizer_attribute(model3, "mu_target", 1e-9)
 
-    optimize!(model3; show_iter_log = false)
+    optimize!(model3; show_iter_log = false, consider_constrained_variables = consider_variable_bounds)
 
     # Auto testing
 
@@ -213,7 +213,7 @@ function iterative_product_mode_02_3_min()
 
 end
 
-function iterative_product_mode_02_1_max()
+function iterative_product_mode_02_1_max(consider_variable_bounds::Bool)
     # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
     # It can be found in section 3 "Numerical Examples"
     # Dataset 1
@@ -261,14 +261,14 @@ function iterative_product_mode_02_1_max()
 
     set_optimizer_attribute(model1, "mu_target", 1e-9)
 
-    optimize!(model1; show_iter_log = false)
+    optimize!(model1; show_iter_log = false, consider_constrained_variables = consider_variable_bounds)
 
     @test isapprox(value(model1[:Q]), 6; atol = 1e-4)
     @test isapprox(value.(model1[:q]).data, [2, 2]; atol = 1e-4)
 
 end
 
-function iterative_product_mode_02_2_max()
+function iterative_product_mode_02_2_max(consider_variable_bounds::Bool)
     # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics" 
     # It can be found in section 3 "Numerical Examples"
     # Dataset 2: 
@@ -314,7 +314,7 @@ function iterative_product_mode_02_2_max()
 
     set_optimizer_attribute(model2, "mu_target", 1e-9)
 
-    optimize!(model2; show_iter_log = false)
+    optimize!(model2; show_iter_log = false, consider_constrained_variables = consider_variable_bounds)
 
     # Auto testing
 
@@ -323,7 +323,7 @@ function iterative_product_mode_02_2_max()
 
 end
 
-function iterative_product_mode_02_3_max()
+function iterative_product_mode_02_3_max(consider_variable_bounds::Bool)
     # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
     # It can be found in section 3 "Numerical Examples"
     # Dataset 3:
@@ -369,7 +369,7 @@ function iterative_product_mode_02_3_max()
 
     set_optimizer_attribute(model3, "mu_target", 1e-9)
 
-    optimize!(model3; show_iter_log = false)
+    optimize!(model3; show_iter_log = false, consider_constrained_variables = consider_variable_bounds)
 
     # Auto testing
 

--- a/test/iterative_product_mode.jl
+++ b/test/iterative_product_mode.jl
@@ -1,0 +1,210 @@
+function iterative_product_mode_01()
+    # This example is from the book Decomposition Techniques in Mathematical Programming, as used in the examples section
+    # Chapter 7.2, page 281, [url](https://www.springer.com/gp/book/9783540276852)
+    iter_eps = [1e-0 * 0.95^i for i = 1:300]
+
+    iter_attr = Dict(
+        "mu_init" => 1e-9,
+        "warm_start_init_point" => "yes",
+        "warm_start_bound_push" => 1e-12,
+        "warm_start_bound_frac" => 1e-12,
+        "warm_start_slack_bound_frac" => 1e-12,
+        "warm_start_slack_bound_push" => 1e-12,
+        "warm_start_mult_bound_push" => 1e-12,
+        # "output_file" => "solver.log",
+        # "file_print_level" => 8,
+        "print_level" => 0,
+    )
+
+    model = BilevelModel(
+        Ipopt.Optimizer,
+        mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+    )
+
+    @variable(Upper(model), x)
+    @variable(UpperOnly(model), z)
+    @variable(Lower(model), y)
+    @variable(LowerOnly(model), w)
+    @objective(Upper(model), Min, -x + 4y + z)
+    @constraint(Upper(model), y + 2x + z <= 9)
+    @constraint(Upper(model), z == 1)
+    @objective(Lower(model), Min, -x - y + w)
+    @constraint(Lower(model), y >= 0)
+    @constraint(Lower(model), x + y + w <= 8)
+    @constraint(Lower(model), x >= 0)
+    @constraint(Lower(model), x <= 4)
+    @constraint(Lower(model), w == 1)
+
+
+    set_optimizer_attribute(model, "mu_target", 1e-9)
+
+    optimize!(model)
+
+    @test value(x) ≈ 1 atol = 1e-4
+    @test value(y) ≈ 6 atol = 1e-4
+    @test value(z) ≈ 1 atol = 1e-4
+    @test value(w) ≈ 1 atol = 1e-4
+
+end
+
+function iterative_product_mode_02_1()
+    # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
+    # It can be found in section 3 "Numerical Examples"
+    # Dataset 1
+
+    F = [1, 2]
+    c = Dict(1 => 1, 2 => 1)
+    C = 1
+    a = 13
+    b = 1
+
+    iter_eps = [1e-0 * 0.95^i for i = 1:300]
+
+    iter_attr = Dict(
+        "mu_init" => 1e-9,
+        "warm_start_init_point" => "yes",
+        "warm_start_bound_push" => 1e-12,
+        "warm_start_bound_frac" => 1e-12,
+        "warm_start_slack_bound_frac" => 1e-12,
+        "warm_start_slack_bound_push" => 1e-12,
+        "warm_start_mult_bound_push" => 1e-12,
+        # "output_file" => "solver.log",
+        # "file_print_level" => 8,
+        "print_level" => 0,
+    )
+
+    model1 = BilevelModel(
+        Ipopt.Optimizer,
+        mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+    )
+
+    @variable(Lower(model1), q[F] >= 0)
+    @variable(Upper(model1), Q >= 0)
+
+    @objective(Upper(model1), Max, ((a - b * (q[1] + q[2] + Q)) * Q - C * Q))
+
+    @objective(
+        Lower(model1),
+        Min,
+        -(
+            (a - b * (q[1] + q[2] + Q)) * q[1] - C * q[1] +
+            (a - b * (q[1] + q[2] + Q)) * q[2] - C * q[2] + b * q[1] * q[2]
+        )
+    )
+
+    set_optimizer_attribute(model1, "mu_target", 1e-9)
+
+    optimize!(model1)
+
+    @test isapprox(value(model1[:Q]), 6; atol = 1e-6)
+    @test isapprox(value.(model1[:q]).data, [2, 2]; atol = 1e-6)
+
+end
+
+function iterative_product_mode_02_2()
+    # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics" 
+    # It can be found in section 3 "Numerical Examples"
+    # Dataset 2: 
+
+    F = [1, 2]
+    c = Dict(1 => 1, 2 => 1)
+    C = 1
+    a = 13
+    b = 0.1
+
+    iter_eps = [1e-0 * 0.95^i for i = 1:300]
+
+    iter_attr = Dict(
+        "mu_init" => 1e-9,
+        "warm_start_init_point" => "yes",
+        "warm_start_bound_push" => 1e-12,
+        "warm_start_bound_frac" => 1e-12,
+        "warm_start_slack_bound_frac" => 1e-12,
+        "warm_start_slack_bound_push" => 1e-12,
+        "warm_start_mult_bound_push" => 1e-12,
+        "print_level" => 0,
+    )
+
+    model2 = BilevelModel(
+        Ipopt.Optimizer,
+        mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+    )
+
+    @variable(Lower(model2), q[F] >= 0)
+    @variable(Upper(model2), Q >= 0)
+
+    @objective(Upper(model2), Max, ((a - b * (q[1] + q[2] + Q)) * Q - C * Q))
+
+    @objective(
+        Lower(model2),
+        Min,
+        -(
+            (a - b * (q[1] + q[2] + Q)) * q[1] - C * q[1] +
+            (a - b * (q[1] + q[2] + Q)) * q[2] - C * q[2] + b * q[1] * q[2]
+        )
+    )
+
+    set_optimizer_attribute(model2, "mu_target", 1e-9)
+
+    optimize!(model2)
+
+    # Auto testing
+
+    @test isapprox(value(model2[:Q]), 60; atol = 1e-6)
+    @test isapprox(value.(model2[:q]).data, [20, 20]; atol = 1e-6)
+
+end
+
+function iterative_product_mode_02_3()
+    # This example is from the paper S. Siddiqui & S. A. Gabriel (2012): "An SOS1-Based Approach for Solving MPECs with a Natural Gas Market Application", as appearing in "Networks and Spatial Economics"
+    # It can be found in section 3 "Numerical Examples"
+    # Dataset 3:
+
+    F = [1, 2]
+    c = Dict(1 => 1, 2 => 1)
+    C = 2
+    a = 13
+    b = 0.1
+
+    iter_eps = [1e-0 * 0.95^i for i = 1:300]
+
+    iter_attr = Dict(
+        "mu_init" => 1e-9,
+        "warm_start_init_point" => "yes",
+        "warm_start_bound_push" => 1e-12,
+        "warm_start_bound_frac" => 1e-12,
+        "warm_start_slack_bound_frac" => 1e-12,
+        "warm_start_slack_bound_push" => 1e-12,
+        "warm_start_mult_bound_push" => 1e-12,
+        "print_level" => 0,
+    )
+
+    model3 = BilevelModel(
+        Ipopt.Optimizer,
+        mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
+    )
+
+    @variable(Lower(model3), q[F] >= 0)
+    @variable(Upper(model3), Q >= 0)
+
+    @objective(Upper(model3), Max, ((a - b * (q[1] + q[2] + Q)) * Q - C * Q))
+
+    @objective(
+        Lower(model3),
+        Min,
+        -(
+            (a - b * (q[1] + q[2] + Q)) * q[1] - C * q[1] +
+            (a - b * (q[1] + q[2] + Q)) * q[2] - C * q[2] + b * q[1] * q[2]
+        )
+    )
+
+    set_optimizer_attribute(model3, "mu_target", 1e-9)
+
+    optimize!(model3)
+
+    # Auto testing
+
+    @test isapprox(value(model3[:Q]), 55; atol = 1e-6)
+    @test isapprox(value.(model3[:q]).data, [18.333, 18.333]; atol = 1e-2)
+
+end

--- a/test/iterative_product_mode.jl
+++ b/test/iterative_product_mode.jl
@@ -20,6 +20,7 @@ function iterative_product_mode_01()
         Ipopt.Optimizer,
         mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
     )
+    set_optimizer_attribute(model, "print_level", 0)
 
     @variable(Upper(model), x)
     @variable(UpperOnly(model), z)
@@ -38,7 +39,7 @@ function iterative_product_mode_01()
 
     set_optimizer_attribute(model, "mu_target", 1e-9)
 
-    optimize!(model)
+    optimize!(model; show_iter_log = false)
 
     @test value(x) ≈ 1 atol = 1e-4
     @test value(y) ≈ 6 atol = 1e-4
@@ -77,6 +78,7 @@ function iterative_product_mode_02_1()
         Ipopt.Optimizer,
         mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
     )
+    set_optimizer_attribute(model1, "print_level", 0)
 
     @variable(Lower(model1), q[F] >= 0)
     @variable(Upper(model1), Q >= 0)
@@ -94,7 +96,7 @@ function iterative_product_mode_02_1()
 
     set_optimizer_attribute(model1, "mu_target", 1e-9)
 
-    optimize!(model1)
+    optimize!(model1; show_iter_log = false)
 
     @test isapprox(value(model1[:Q]), 6; atol = 1e-6)
     @test isapprox(value.(model1[:q]).data, [2, 2]; atol = 1e-6)
@@ -129,6 +131,7 @@ function iterative_product_mode_02_2()
         Ipopt.Optimizer,
         mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
     )
+    set_optimizer_attribute(model2, "print_level", 0)
 
     @variable(Lower(model2), q[F] >= 0)
     @variable(Upper(model2), Q >= 0)
@@ -146,7 +149,7 @@ function iterative_product_mode_02_2()
 
     set_optimizer_attribute(model2, "mu_target", 1e-9)
 
-    optimize!(model2)
+    optimize!(model2; show_iter_log = false)
 
     # Auto testing
 
@@ -183,6 +186,7 @@ function iterative_product_mode_02_3()
         Ipopt.Optimizer,
         mode = BilevelJuMP.ProductMode(1e-0; iter_eps = iter_eps, iter_attr = iter_attr),
     )
+    set_optimizer_attribute(model3, "print_level", 0)
 
     @variable(Lower(model3), q[F] >= 0)
     @variable(Upper(model3), Q >= 0)
@@ -200,7 +204,7 @@ function iterative_product_mode_02_3()
 
     set_optimizer_attribute(model3, "mu_target", 1e-9)
 
-    optimize!(model3)
+    optimize!(model3; show_iter_log = false)
 
     # Auto testing
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -396,9 +396,12 @@ end
 
 @testset "Iterative Product Mode" begin
     iterative_product_mode_01()
-    iterative_product_mode_02_1()
-    iterative_product_mode_02_2()
-    iterative_product_mode_02_3()
+    iterative_product_mode_02_1_min()
+    iterative_product_mode_02_2_min()
+    iterative_product_mode_02_3_min()
+    iterative_product_mode_02_1_max()
+    iterative_product_mode_02_2_max()
+    iterative_product_mode_02_3_max()
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,7 @@ include("moi.jl")
 include("jump.jl")
 include("jump_unit.jl")
 include("jump_nlp.jl")
+include("iterative_product_mode.jl")
 
 @testset "BilevelJuMP tests" begin
 @testset "MibS" begin
@@ -391,6 +392,13 @@ end
         @time jump_conic03(solver.opt, solver.mode, config, bounds = true)
         @time jump_conic04(solver.opt, solver.mode, config, bounds = true)
     end
+end
+
+@testset "Iterative Product Mode" begin
+    iterative_product_mode_01()
+    iterative_product_mode_02_1()
+    iterative_product_mode_02_2()
+    iterative_product_mode_02_3()
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -395,13 +395,15 @@ end
 end
 
 @testset "Iterative Product Mode" begin
-    iterative_product_mode_01()
-    iterative_product_mode_02_1_min()
-    iterative_product_mode_02_2_min()
-    iterative_product_mode_02_3_min()
-    iterative_product_mode_02_1_max()
-    iterative_product_mode_02_2_max()
-    iterative_product_mode_02_3_max()
+    for consider_variable_bounds in [true, false]
+        iterative_product_mode_01(consider_variable_bounds)
+        iterative_product_mode_02_1_min(consider_variable_bounds)
+        iterative_product_mode_02_2_min(consider_variable_bounds)
+        iterative_product_mode_02_3_min(consider_variable_bounds)
+        iterative_product_mode_02_1_max(consider_variable_bounds)
+        iterative_product_mode_02_2_max(consider_variable_bounds)
+        iterative_product_mode_02_3_max(consider_variable_bounds)
+    end
 end
 
 end


### PR DESCRIPTION
This is a first attempt to specifically consider variable bounds via complements. 
It should reduce solution times, since one dual variable per variable bound can be saved.
This PR also includes previous commits from https://github.com/joaquimg/BilevelJuMP.jl/pull/184 to check it also works with the iterative ProductMode.
@joaquimg could you take a look at the commits Oct. 5th and later?
Think this might be an easy way for https://github.com/joaquimg/BilevelJuMP.jl/issues/163. 
I believe it should work well except for aggregation and conic. 
Sorry for the spam the last few days :D