### PR TITLE
Test with Alpine

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -8,7 +8,12 @@ QuadraticToBinary = "014a38d5-7acb-4e20-b6c0-4fe5c2344fd1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
+Alpine = "07493b3f-dabb-5b16-a503-4139292d7dd4"
+HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
+
 [compat]
 Ipopt = "=1.0.2"
 MibS_jll = "=1.1.3"
 QuadraticToBinary = "=0.4.0"
+
+Alpine = "=0.5.3"

--- a/test/jump.jl
+++ b/test/jump.jl
@@ -2888,14 +2888,14 @@ By: LukasBarner
 Siddiqui S, Gabriel SA (2013). An sos1-based approach for solving mpecs with a natural gas market applica-
 tion. Networks and Spatial Economics 13(2):205–227.
 """
-function jump_qp_lower_min(config = Config())
+function jump_qp_lower_min(optimizer, config = Config())
     F = [1,2]
     c = Dict(1=>1, 2=>1)
     C = 1
     a = 13
     b = 1
 
-    model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode())
+    model = BilevelModel(()->optimizer, mode = BilevelJuMP.ProductMode())
 
     @variable(Lower(model), q[F] >= 0)
     @variable(Upper(model), Q >= 0)
@@ -2909,14 +2909,14 @@ function jump_qp_lower_min(config = Config())
     @test isapprox(value.(Q), 6; atol=1e-5)
     @test isapprox(value.(q).data, [2,2]; atol=1e-5)
 end
-function jump_qp_lower_max(config = Config())
+function jump_qp_lower_max(optimizer, config = Config())
     F = [1,2]
     c = Dict(1=>1, 2=>1)
     C = 1
     a = 13
     b = 1
 
-    model = BilevelModel(Ipopt.Optimizer, mode = BilevelJuMP.ProductMode())
+    model = BilevelModel(()->optimizer, mode = BilevelJuMP.ProductMode())
 
     @variable(Lower(model), q[F] >= 0)
     @variable(Upper(model), Q >= 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,16 +51,16 @@ solvers_fa = OptModeType[]
 solvers_fa2 = OptModeType[] # explicit big-M at 100
 solvers_complements = OptModeType[]
 
-include("solvers/ipopt.jl")
+# include("solvers/ipopt.jl")
 # include("solvers/scip.jl")
 # include("solvers/cbc.jl")
-if Sys.iswindows() && (
-    get(ENV, "SECRET_XPRS_WIN_8110", "") != "" ||
-    get(ENV, "XPRESSDIR", "") != ""
-)
-    @info "Running Xpress in Tests"
-    include("solvers/xpress.jl")
-end
+# if Sys.iswindows() && (
+#     get(ENV, "SECRET_XPRS_WIN_8110", "") != "" ||
+#     get(ENV, "XPRESSDIR", "") != ""
+# )
+#     @info "Running Xpress in Tests"
+#     include("solvers/xpress.jl")
+# end
 # DONE
 # include("solvers/gurobi.jl")
 # include("solvers/knitro.jl")
@@ -69,7 +69,7 @@ end
 # include("solvers/bonmin.jl")
 # include("solvers/baron.jl")
 # TODO
-# include("solvers/alpine.jl") # require NLP from JuMP
+include("solvers/alpine.jl") # require NLP from JuMP
 # include("solvers/pavito.jl") # require NLP from JuMP
 # include("solvers/juniper.jl") # require NLP from JuMP
 # include("solvers/path.jl") # require LCP method
@@ -81,14 +81,18 @@ include("jump_nlp.jl")
 
 @testset "BilevelJuMP tests" begin
     @testset "MibS" begin
-        include("mibs.jl")
+        # include("mibs.jl")
     end
 
     @testset "nlp" begin
-        jump_nlp_01(IPO_OPT; mode = BilevelJuMP.ProductMode(1e-8))
-        jump_nlp_02(IPO_OPT; mode = BilevelJuMP.ProductMode(1e-8))
-        jump_nlp_03(IPO_OPT; mode = BilevelJuMP.ProductMode(1e-8))
-        jump_nlp_04(IPO_OPT; mode = BilevelJuMP.ProductMode(1e-8))
+        # jump_nlp_01(IPO_OPT; mode = BilevelJuMP.ProductMode(1e-8))
+        # jump_nlp_02(IPO_OPT; mode = BilevelJuMP.ProductMode(1e-8))
+        # jump_nlp_03(IPO_OPT; mode = BilevelJuMP.ProductMode(1e-8))
+        # jump_nlp_04(IPO_OPT; mode = BilevelJuMP.ProductMode(1e-8))
+    end
+    @testset "Lower QP" begin
+        # jump_qp_lower_min(IPO_OPT)
+        # jump_qp_lower_max(IPO_OPT)
     end
 
     @testset "Unit" begin
@@ -370,11 +374,6 @@ include("jump_nlp.jl")
             # jump_fanzeres2017(solver.opt, solver.mode)
             jump_eq_price(solver.opt, solver.mode)
         end
-    end
-
-    @testset "Lower QP" begin
-        jump_qp_lower_min()
-        jump_qp_lower_max()
     end
 
     @testset "Fruits" begin

--- a/test/solvers/alpine.jl
+++ b/test/solvers/alpine.jl
@@ -1,19 +1,20 @@
 # name = "Alpine"
 # Alpine = "07493b3f-dabb-5b16-a503-4139292d7dd4"
 
-using Alpine, Ipopt, Cbc
+using Alpine, Ipopt, HiGHS
 
 const ALP_IPOPT = optimizer_with_attributes(Ipopt.Optimizer, MOI.Silent() => true, "sb" => "yes")
-const ALP_CBC = optimizer_with_attributes(Cbc.Optimizer, MOI.Silent() => true)
+const ALP_HIGHS = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
+# HiGHS
 
 # ALP_OPT = optimizer_with_attributes(Alpine.Optimizer, "nlp_solver" => ALP_IPOPT,
-# "mip_solver" => ALP_CBC,
+# "mip_solver" => ALP_HIGHS,
 # "loglevel" => 100)
 # ALP = ALP_OPT
 
 ALP_OPT = Alpine.Optimizer()
-MOI.set(ALP_OPT, MOI.RawParameter("nlp_solver"), ALP_IPOPT)
-MOI.set(ALP_OPT, MOI.RawParameter("mip_solver"), ALP_CBC)
+MOI.set(ALP_OPT, MOI.RawOptimizerAttribute("nlp_solver"), ALP_IPOPT)
+MOI.set(ALP_OPT, MOI.RawOptimizerAttribute("mip_solver"), ALP_HIGHS)
 ALP = MOI.Bridges.Constraint.SOCtoNonConvexQuad{Float64}(ALP_OPT)
 
 push!(solvers_nlp_lowtol, (opt = ALP, mode = BilevelJuMP.ProductMode(1e-5)))


### PR DESCRIPTION
Running alpine with Ipopt+HiGHS.

Most cases fail.

1 - Many seem sem to be trying to add a quadratic constraint to HiGHS:
```julia
 Constraints of type MathOptInterface.ScalarQuadraticFunction{Float64}-in-MathOptInterface.GreaterThan{Float64} are not supported by the solver.

  If you expected the solver to support your problem, you may have an error in your formulation. Otherwise, consider using a different solver.

  The list of available solvers, along with the problem types they support, is available at https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers.
  Stacktrace:
    [1] error(s::String)
      @ Base .\error.jl:35
    [2] _moi_add_constraint(model::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.Bridges.LazyBridgeOptimizer{HiGHS.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}, f::MathOptInterface.ScalarQuadraticFunction{Float64}, s::MathOptInterface.GreaterThan{Float64})
```

I would expect that quadratic constraints are forwarded to Ipopt as non-linear constraints.

2 - Another common error is:
```julia
  Got exception outside of a @test
  Result index of attribute MathOptInterface.ObjectiveValue(1) out of bounds. There are currently 0 solution(s) in the model.
  Stacktrace:
    [1] check_result_index_bounds
      @ C:\Users\joaquimgarcia\.julia\packages\MathOptInterface\NCblk\src\attributes.jl:207 [inlined]
    [2] get
      @ C:\Users\joaquimgarcia\.julia\packages\HiGHS\QRk9O\src\MOI_wrapper.jl:1880 [inlined]
    [3] get(b::MathOptInterface.Bridges.LazyBridgeOptimizer{HiGHS.Optimizer}, attr::MathOptInterface.Bridges.ObjectiveFunctionValue{MathOptInterface.ScalarAffineFunction{Float64}})
```
Seems that Alpine is not handling some HiGHS fails well. Possibly due unbounded variables?

cc @harshangrjn @odow 