### PR TITLE
Stop using private MOI.Utilities methods in append_to

### DIFF
--- a/src/moi.jl
+++ b/src/moi.jl
@@ -306,7 +306,7 @@ function build_bilevel(
     end
 
     # append the second level primal
-    append_to(m, lower, lower_idxmap; allow_single_bounds = true)
+    append_to(m, lower, lower_idxmap)
     if copy_names
         pass_names(m, lower, lower_idxmap)
     end

--- a/src/moi_utilities.jl
+++ b/src/moi_utilities.jl
@@ -22,80 +22,138 @@ function pass_names(dest, src, map)
     end
 end
 
-function append_to(
-    dest::MOI.ModelLike,
-    src::MOI.ModelLike,
-    idxmap,
-    filter_constraints::Union{Nothing,Function} = nothing;
-    allow_single_bounds::Bool = true,
-)
-    #=
-        This function follows closely the function `default_copy_to` defined in
-        MathOptInterface.Utilities
-        due to some caveats of this function we keep the commented functions
-        from the original function to highlight the differences and
-        ease the burden of updating when `default_copy_to` is updated.
-    =#
-
-    # MOI.empty!(dest)
-
-    # idxmap = MOIU.IndexMap()
-
-    vis_src = MOI.get(src, MOI.ListOfVariableIndices())
-    # index_map_for_variable_indices only initializes the data structure
-    # idxmap = index_map_for_variable_indices(vis_src)
-
+# Add every variable and constraint of `src` to `dest`, extending `idxmap` with
+# the new indices, and return `idxmap`.
+#
+# Unlike `MOI.Utilities.default_copy_to`, `dest` is not emptied and `idxmap` is
+# expected to come in partially filled: variables that appear in more than one
+# level are added once and then shared, so the entries already in `idxmap` are
+# reused instead of creating duplicates. Model attributes are deliberately NOT
+# copied, the objective function in particular, since `dest` holds the objective
+# of the upper level.
+#
+# This used to be a copy of `default_copy_to` that called into
+# `MOI.Utilities._try_constrain_variables_on_creation` and
+# `MOI.Utilities._pass_constraints`, which are private (#218). Those two are
+# spelled out below; the public `MOI.Utilities` functions that `default_copy_to`
+# uses are still called directly.
+#
+# The steps are kept in the same order as `default_copy_to`, down to which
+# variables are constrained on creation: the order in which variables reach the
+# solver changes its iterates, and the tests do check numbers that a nonlinear
+# solver only gets right to a tolerance.
+function append_to(dest::MOI.ModelLike, src::MOI.ModelLike, idxmap)
     # The `NLPBlock` assumes that the order of variables does not change (#849)
     if MOI.NLPBlock() in MOI.get(src, MOI.ListOfModelAttributesSet())
         error("NLP models are not supported.")
-        # constraint_types = MOI.get(src, MOI.ListOfConstraints())
-        # single_variable_types = [S for (F, S) in constraint_types
-        #                          if F == MOI.VariableIndex]
-        # vector_of_variables_types = [S for (F, S) in constraint_types
-        #                              if F == MOI.VectorOfVariables]
-        # vector_of_variables_not_added = [
-        #     MOI.get(src, MOI.ListOfConstraintIndices{MOI.VectorOfVariables, S}())
-        #     for S in vector_of_variables_types
-        # ]
-        # single_variable_not_added = [
-        #     MOI.get(src, MOI.ListOfConstraintIndices{MOI.VariableIndex, S}())
-        #     for S in single_variable_types
-        # ]
-    else
-        # the key assumption here is that MOI keeps the following behaviour
-        # "The copy is only done when
-        # the variables to be copied are not already keys of `idxmap`. It returns a list
-        # of the constraints copied and not copied."
-        # from copy_single_variable and copy_vector_of_variables.
-        # this is very important because variables are shared between
-        # upper, lower and lower dual levels
-        constraints_not_added = Any[
-            MOIU._try_constrain_variables_on_creation(dest, src, idxmap, S)
-            for S in MOIU.sorted_variable_sets_by_cost(dest, src)
-        ]
     end
-
-    # MOIU.copy_free_variables(dest, idxmap, vis_src, MOI.add_variables)
-    # copy variables has a size check that does not generalize here
-    # because we have previously added variables
+    # Variables that carry a `VariableIndex`/`VectorOfVariables` constraint are
+    # added together with it, and so come first. Whatever is left over - both
+    # the free variables and the constraints that could not be added this way -
+    # is added below.
+    not_added = Any[
+        _add_constrained_variables(dest, src, idxmap, S) for
+        S in MOIU.sorted_variable_sets_by_cost(dest, src)
+    ]
+    vis_src = MOI.get(src, MOI.ListOfVariableIndices())
     for vi in vis_src
-        if !haskey(idxmap.var_map, vi)
-            var = MOI.add_variable(dest)
-            idxmap.var_map[vi] = var
+        if !haskey(idxmap, vi)
+            idxmap[vi] = MOI.add_variable(dest)
         end
     end
-
-    # Copy variable attributes
     MOIU.pass_attributes(dest, src, idxmap, vis_src)
-
-    # Copy model attributes
-    # attention HERE to no pass objective functions!
-    # pass_attributes(dest, src, copy_names, idxmap)
-
-    # Copy constraints
-    MOIU._pass_constraints(dest, src, idxmap, constraints_not_added)
-
+    # Model attributes are deliberately NOT copied, the objective function in
+    # particular, since `dest` holds the objective of the upper level.
+    #
+    # What follows is `MOI.Utilities._pass_constraints`.
+    for cis_src in not_added
+        _copy_constraints(dest, src, idxmap, cis_src)
+    end
+    constraint_types = MOI.get(src, MOI.ListOfConstraintTypesPresent())
+    nonvariable_constraint_types = filter(constraint_types) do (F, S)
+        return !(F <: Union{MOI.VariableIndex,MOI.VectorOfVariables})
+    end
+    MOIU.pass_nonvariable_constraints(
+        dest,
+        src,
+        idxmap,
+        nonvariable_constraint_types,
+    )
+    for (F, S) in constraint_types
+        cis_src = MOI.get(src, MOI.ListOfConstraintIndices{F,S}())
+        MOIU.pass_attributes(dest, src, idxmap, cis_src)
+    end
     return idxmap
+end
+
+# Add the variables of the `VariableIndex`-in-`S` constraints of `src` to `dest`
+# with `MOI.add_constrained_variable`, and return the constraints that could not
+# be added that way because their variable is shared with another level and is
+# therefore already in `idxmap`.
+function _add_constrained_variables(
+    dest::MOI.ModelLike,
+    src::MOI.ModelLike,
+    idxmap,
+    ::Type{S},
+) where {S<:MOI.AbstractScalarSet}
+    F = MOI.VariableIndex
+    not_added = MOI.ConstraintIndex{F,S}[]
+    for ci in MOI.get(src, MOI.ListOfConstraintIndices{F,S}())
+        func = MOI.get(src, MOI.ConstraintFunction(), ci)
+        if haskey(idxmap, func)
+            push!(not_added, ci)
+        else
+            set = MOI.get(src, MOI.ConstraintSet(), ci)::S
+            vi_dest, ci_dest = MOI.add_constrained_variable(dest, set)
+            idxmap[ci] = ci_dest
+            idxmap[func] = vi_dest
+        end
+    end
+    return not_added
+end
+
+# Same as above for `VectorOfVariables`-in-`S`. A constraint whose function
+# repeats a variable cannot be added on creation either.
+function _add_constrained_variables(
+    dest::MOI.ModelLike,
+    src::MOI.ModelLike,
+    idxmap,
+    ::Type{S},
+) where {S<:MOI.AbstractVectorSet}
+    F = MOI.VectorOfVariables
+    not_added = MOI.ConstraintIndex{F,S}[]
+    for ci in MOI.get(src, MOI.ListOfConstraintIndices{F,S}())
+        func = MOI.get(src, MOI.ConstraintFunction(), ci)
+        if !allunique(func.variables) ||
+           any(vi -> haskey(idxmap, vi), func.variables)
+            push!(not_added, ci)
+        else
+            set = MOI.get(src, MOI.ConstraintSet(), ci)::S
+            vis_dest, ci_dest = MOI.add_constrained_variables(dest, set)
+            idxmap[ci] = ci_dest
+            for (vi_src, vi_dest) in zip(func.variables, vis_dest)
+                idxmap[vi_src] = vi_dest
+            end
+        end
+    end
+    return not_added
+end
+
+# Copy the constraints `cis_src` of `src` over to `dest`, without their
+# attributes. This mirrors the private `MOI.Utilities._copy_constraints`.
+function _copy_constraints(
+    dest::MOI.ModelLike,
+    src::MOI.ModelLike,
+    idxmap,
+    cis_src,
+)
+    for ci in cis_src
+        func = MOI.get(src, MOI.ConstraintFunction(), ci)
+        set = MOI.get(src, MOI.ConstraintSet(), ci)
+        func = MOIU.map_indices(idxmap, func)
+        idxmap[ci] = MOI.add_constraint(dest, func, set)
+    end
+    return nothing
 end
 
 # scalar


### PR DESCRIPTION
Closes #218.

`append_to` is a copy of `MOI.Utilities.default_copy_to` adapted to append to a
non-empty destination, and it called two private `MOI.Utilities` functions:

- `_try_constrain_variables_on_creation`
- `_pass_constraints`

The first is now dead code inside MOI, kept only because downstream packages call
it — MOI 1.52 files it under *"These methods are deprecated, but unfortunately,
they are used by a number of downstream packages and JuMP extensions"*, and
jump-dev/MathOptInterface#2520 was a revert forced by its removal breaking this
package, ParametricOptInterface and Plasmo.

## What changed

Those two are spelled out locally, along with `_copy_constraints`, which is
private as well and which `_pass_constraints` needs. Everything public that
`default_copy_to` uses is still called directly rather than reimplemented:
`sorted_variable_sets_by_cost`, `pass_attributes`,
`pass_nonvariable_constraints` and `map_indices`.

Two parameters of `append_to` were accepted and then ignored —
`filter_constraints` and `allow_single_bounds` — and are removed along with the
single call site that passed `allow_single_bounds = true`.

## On keeping the ordering

The constrained-on-creation pass is kept rather than dropped, which is worth
explaining because dropping it is the obvious simplification and it does not
work.

Its purpose is to present variables to the final solver in the cheapest-to-bridge
form, and it cannot serve that purpose here: the destination in `build_bilevel`
is always a `CachingOptimizer` over a `UniversalFallback`, which supports every
function-set pair, so `add_constrained_variable` and `add_variable` +
`add_constraint` are equivalent, and the choice that matters is made later by the
`MOI.copy_to` that hands the single model to the solver.

What it does affect is the order variables and constraints are added in, and that
order changes a nonlinear solver's iterates. A first version of this PR dropped
the pass; CI came back with `jump_03` failing on `dual(u1) ≈ 0 atol=1e-3` at
`0.0074`, on Julia 1.12 only. So the order is load-bearing for the test suite even
though it is not load-bearing for correctness, and this version reproduces it
exactly.

## Behaviour

No functional change: the single MOI model handed to the solver is byte-identical
to the one built before. Verified by dumping it via
`optimize!(model; bilevel_prob = ...)` on this branch and on `master`, over models
covering free variables only, scalar variable sets, vector variable sets (SOC) and
`DualOf`, and diffing — identical on all of them, where the ordering-changing
version differed on the vector-set one.

Full suite locally (MOI 1.52.0, Ipopt 1.0.2, Julia 1.11): 887/887 on both this
branch and `master`, with Ipopt returning identical digits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
