### PR TITLE
Update Ipopt and MibS_jll bounds, and parse the new MibS output

### DIFF
--- a/src/mibs.jl
+++ b/src/mibs.jl
@@ -395,11 +395,44 @@ function _mibs_solution(model::BilevelModel)
     return model.solution::MibSSolution
 end
 
-# MibS reports values as `x[i]` for the upper level block and `y[i]` for the
-# lower level block, numbered from zero within each block, and only after it
-# announces an optimal solution. It reports infeasibility through the underlying
-# ALPS search, hence the two different markers.
-function _parse_mibs_solution(output::AbstractString, upper, lower)
+# MibS reports the solution after announcing an optimal one, and reports
+# infeasibility through the underlying ALPS search, hence the two markers.
+#
+# Two output formats are supported, because MibS changed it between the
+# versions in the General registry:
+#
+#   * up to MibS_jll 100.100.301, values are indexed within each level block,
+#     numbered from zero, and only the non-default ones are listed:
+#
+#         Optimal solution:
+#         Cost = 8
+#         x[0] = 8
+#
+#   * from MibS_jll 100.200.200, values are given by variable name, grouped
+#     under a header per level:
+#
+#         Optimal solution:
+#         Cost = 8
+#         First stage (upper level) variable values:
+#         y = 8
+#         Second stage (lower level) variable values:
+#
+# The name form is matched against the MPS column names, which is what
+# `by_name` is built from at the call site. Unlisted variables are zero in
+# both formats.
+const _MIBS_UPPER_HEADER = "First stage (upper level) variable values:"
+const _MIBS_LOWER_HEADER = "Second stage (lower level) variable values:"
+
+# The trailing statistics that MibS prints after the solution also look like
+# `key = value`, so parsing by name has to stop instead of reading to the end.
+function _is_mibs_solution_line(line)
+    return !occursin("Number of ", line) &&
+           !occursin("Time for ", line) &&
+           !startswith(strip(line), "=====") &&
+           !isempty(strip(line))
+end
+
+function _parse_mibs_solution(output::AbstractString, upper, lower, by_name)
     lines = split(output, '\n')
     values = Dict{MOI.VariableIndex,Float64}()
     start = findfirst(l -> occursin("Optimal solution", l), lines)
@@ -416,14 +449,36 @@ function _parse_mibs_solution(output::AbstractString, upper, lower)
     for v in vcat(upper, lower)
         values[v] = 0.0
     end
+    block = nothing
     for line in lines[(start+1):end]
-        m = match(r"([xy])\[([0-9]+)\] *= *(.+)", line)
-        m === nothing && continue
-        block = m[1] == "x" ? upper : lower
-        i = parse(Int, m[2]) + 1
-        if 1 <= i <= length(block)
-            values[block[i]] = parse(Float64, strip(m[3]))
+        stripped = strip(line)
+        if occursin(_MIBS_UPPER_HEADER, stripped)
+            block = :upper
+            continue
+        elseif occursin(_MIBS_LOWER_HEADER, stripped)
+            block = :lower
+            continue
         end
+        # Indexed form, which carries its own level in the variable letter.
+        m = match(r"([xy])\[([0-9]+)\] *= *(.+)", line)
+        if m !== nothing
+            level = m[1] == "x" ? upper : lower
+            i = parse(Int, m[2]) + 1
+            if 1 <= i <= length(level)
+                values[level[i]] = parse(Float64, strip(m[3]))
+            end
+            continue
+        end
+        # Name form, only inside one of the two level sections.
+        block === nothing && continue
+        _is_mibs_solution_line(line) || continue
+        m = match(r"^ *([^ =]+) *= *(.+?) *$", line)
+        m === nothing && continue
+        v = get(by_name, String(m[1]), nothing)
+        v === nothing && continue
+        value = tryparse(Float64, strip(m[2]))
+        value === nothing && continue
+        values[v] = value
     end
     return MOI.OPTIMAL, MOI.FEASIBLE_POINT, String(strip(lines[start])), values
 end
@@ -501,7 +556,7 @@ function _optimize!(model::BilevelModel, mode::MibSMode; kwargs...)
         ordered_upper =
             [by_name[name] for name in columns if !(by_name[name] in lower_set)]
         status, primal_status, raw, values =
-            _parse_mibs_solution(output, ordered_upper, ordered_lower)
+            _parse_mibs_solution(output, ordered_upper, ordered_lower, by_name)
         primal = Dict{Int,Float64}()
         for (idx, v) in model.var_upper
             vi = JuMP.index(v)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -12,10 +12,6 @@ Xpress_jll = "308bddfa-7f95-4fa6-a557-f2c7addc1869"
 
 [compat]
 Ipopt = "1"
-# MibS versions are listed explicitly rather than as a range: MibS changes
-# its solution output format between releases (see `_parse_mibs_solution`),
-# so a new one has to be tested before being allowed here. 1.1.3 is left
-# out because its binary fails to load from Ipopt 1.11 onwards.
 MibS_jll = "=100.100.301, =100.200.200"
 QuadraticToBinary = "=0.4.0"
 Xpress = "0.18"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -11,8 +11,12 @@ Xpress = "9e70acf3-d6c9-5be6-b5bd-4e2c73e3e054"
 Xpress_jll = "308bddfa-7f95-4fa6-a557-f2c7addc1869"
 
 [compat]
-Ipopt = "=1.0.2"
-MibS_jll = "=1.1.3"
+Ipopt = "1"
+# MibS versions are listed explicitly rather than as a range: MibS changes
+# its solution output format between releases (see `_parse_mibs_solution`),
+# so a new one has to be tested before being allowed here. 1.1.3 is left
+# out because its binary fails to load from Ipopt 1.11 onwards.
+MibS_jll = "=100.100.301, =100.200.200"
 QuadraticToBinary = "=0.4.0"
 Xpress = "0.18"
 Xpress_jll = "=9.8.0"

--- a/test/test_mibs.jl
+++ b/test/test_mibs.jl
@@ -8,6 +8,8 @@ module TestMIBS
 using BilevelJuMP
 using Test
 
+import MathOptInterface as MOI
+
 # Tests named `test_solver_*` run the MibS binary; the rest only build the files
 # that would be handed to it, and so can run anywhere.
 const MIBS_AVAILABLE = try
@@ -819,6 +821,103 @@ function test_no_mode_selected()
     @objective(Lower(model), Min, y)
     @constraint(Lower(model), l1, x + y <= 8)
     @test_throws ErrorException optimize!(model)
+    return
+end
+
+# MibS changed its solution output format between the versions in the General
+# registry, so the parser understands both. These run without the binary.
+function test_parse_solution_indexed_format()
+    u1, u2 = MOI.VariableIndex(1), MOI.VariableIndex(2)
+    l1 = MOI.VariableIndex(3)
+    by_name = Dict("xa" => u1, "xb" => u2, "ya" => l1)
+    output = """
+    ============================================
+    Optimal solution:
+    Cost = 8
+    x[0] = 8
+    y[0] = 6
+    Number of problems (VF) solved = 5
+    ============================================
+    """
+    status, primal_status, _, values =
+        BilevelJuMP._parse_mibs_solution(output, [u1, u2], [l1], by_name)
+    @test status == MOI.OPTIMAL
+    @test primal_status == MOI.FEASIBLE_POINT
+    @test values[u1] == 8.0
+    @test values[u2] == 0.0  # not listed, hence at its default
+    @test values[l1] == 6.0
+    return
+end
+
+function test_parse_solution_named_format()
+    u1, u2 = MOI.VariableIndex(1), MOI.VariableIndex(2)
+    l1 = MOI.VariableIndex(3)
+    by_name = Dict("xa" => u1, "xb" => u2, "ya" => l1)
+    output = """
+    ============================================
+    Optimal solution:
+    Cost = 8
+    First stage (upper level) variable values:
+    xa = 8
+    xb = 2.5
+    Second stage (lower level) variable values:
+    ya = 6
+    Number of problems (VF) solved = 5
+    Time for solving problem (VF) = 0.0039
+    Number of Hypercube Intersection Cuts Generated: 4
+    ============================================
+    """
+    status, primal_status, _, values =
+        BilevelJuMP._parse_mibs_solution(output, [u1, u2], [l1], by_name)
+    @test status == MOI.OPTIMAL
+    @test primal_status == MOI.FEASIBLE_POINT
+    @test values[u1] == 8.0
+    @test values[u2] == 2.5
+    @test values[l1] == 6.0
+    return
+end
+
+# The statistics printed after the solution also read as `key = value`.
+function test_parse_solution_ignores_trailing_statistics()
+    u1 = MOI.VariableIndex(1)
+    l1 = MOI.VariableIndex(2)
+    by_name = Dict("xa" => u1, "ya" => l1)
+    output = """
+    Optimal solution:
+    Cost = 8
+    First stage (upper level) variable values:
+    xa = 1
+    Second stage (lower level) variable values:
+    Number of problems (VF) solved = 999
+    Time for solving problem (UB) = 0
+    """
+    _, _, _, values =
+        BilevelJuMP._parse_mibs_solution(output, [u1], [l1], by_name)
+    @test values[u1] == 1.0
+    @test values[l1] == 0.0
+    @test length(values) == 2
+    return
+end
+
+function test_parse_solution_infeasible_and_unknown()
+    u1 = MOI.VariableIndex(1)
+    by_name = Dict("xa" => u1)
+    status, primal_status, _, _ = BilevelJuMP._parse_mibs_solution(
+        "Problem is infeasible\n",
+        [u1],
+        MOI.VariableIndex[],
+        by_name,
+    )
+    @test status == MOI.INFEASIBLE
+    @test primal_status == MOI.NO_SOLUTION
+    status, primal_status, _, _ = BilevelJuMP._parse_mibs_solution(
+        "something unexpected\n",
+        [u1],
+        MOI.VariableIndex[],
+        by_name,
+    )
+    @test status == MOI.OTHER_ERROR
+    @test primal_status == MOI.NO_SOLUTION
     return
 end
 


### PR DESCRIPTION
Replaces #227, which needed `MibS_jll` updated for aarch64-apple-darwin but could not merge as-is.

`test/Project.toml` pinned `Ipopt = "=1.0.2"` and `MibS_jll = "=1.1.3"`. The MibS pin is the blocker for aarch64-apple-darwin, which has no 1.1.3 build.

### Bumping MibS_jll alone silently breaks the tests

MibS changed its solution output between `100.100.301` and `100.200.200`. Values used to be indexed within each level block:

```
Optimal solution:
Cost = 8
x[0] = 8
```

and are now named after the MPS columns, grouped under a header per level:

```
Optimal solution:
Cost = 8
First stage (upper level) variable values:
y = 8
Second stage (lower level) variable values:
```

`_parse_mibs_solution` only matched the indexed form. It keys the status off the `Optimal solution` line and pre-fills every variable with zero, so the new output was not reported as an error — it came back as `OPTIMAL` with an all-zero solution. On the same model:

| MibS_jll | result |
|---|---|
| 1.1.3 | `obj=-20.0, x=8.0, y=6.0` ✅ |
| 100.200.200 (before this PR) | `obj=0.0, x=0.0, y=0.0` ❌ reported `OPTIMAL` |

That is **31 of 118 MibS tests failing**, each comparing a real value against `0.0`. A silent wrong answer rather than a clean failure, which is why this is worth fixing rather than pinning around.

### The fix

Teach the parser both forms. The named form resolves through the `by_name` map already built at the call site, so it adds no bookkeeping. It is read only inside the two level sections, because the statistics MibS prints after the solution (`Number of problems (VF) solved = 5`, `Time for solving problem (UB) = 0`) otherwise parse as variables.

Each allowed `MibS_jll` version is listed explicitly rather than as a range:

```toml
MibS_jll = "=100.100.301, =100.200.200"
```

Because the output format changes between releases, a range would silently pick up an untested version and could reintroduce exactly the all-zeros failure above. Listing them means a new MibS release has to be checked against the parser before it is allowed in. The registry currently holds no versions between these two.

`1.1.3` is deliberately excluded. Its binary fails to load from Ipopt 1.11 onwards:

```
could not load library "libMibs-0.dll"
```

I bisected this: it works up to Ipopt 1.10.6 and breaks at 1.11.0, so it cannot coexist with widening Ipopt to `"1"`. (It does pass 135/135 when held back to Ipopt 1.0.2, so the binary itself is fine — it just is not compatible with the newer dependency tree.)

### Verification

Full test suite, run against both formats:

| config | result |
|---|---|
| MibS_jll 100.100.301 (indexed output) | **1004/1004 pass** |
| MibS_jll 100.200.200 (named output) | **1004/1004 pass** |

Both listed versions are covered, so neither format is taken on trust.

MibS testset specifically: 135/135 (118 existing + 17 new).

The parser is also covered by direct unit tests that need no binary, so they run on platforms where MibS is unavailable — including the exact regression above, and a case asserting the trailing statistics are not mistaken for variables.

`Ipopt = "1"` resolves to 1.15.0 at the loose end; I ran the tolerance-sensitive tests against it separately (114 assertions) before settling on this bound.

Note `test/Manifest.toml` is untracked, so CI resolves fresh and will pick the newest versions the bounds allow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
