### PR TITLE
Add a tutorial on variable levels

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -87,6 +87,7 @@ makedocs(;
             "tutorials",
             [
                 "getting_started.md",
+                "variable_levels.md",
                 "modes.md",
                 "lower_duals.md",
                 "conic_lower.md",

--- a/docs/src/tutorials/variable_levels.jl
+++ b/docs/src/tutorials/variable_levels.jl
@@ -1,0 +1,156 @@
+# # Variable levels
+
+# In a bilevel problem every variable belongs to a level: it is decided either
+# by the upper level (the leader) or by the lower level (the follower).
+# `Upper` and `Lower` say which level decides a variable, and both make the
+# variable visible to the other level. `UpperOnly` and `LowerOnly` restrict that
+# visibility. In some situations this might simplify formulations.
+
+# This tutorial goes through the four constructors and when each is the right
+# choice.
+
+using BilevelJuMP, HiGHS
+
+# ## `Upper` and `Lower`
+
+# These are the two used in most models. A variable created with either is
+# *shared*: both levels may use it in their objectives and constraints.
+
+model = BilevelModel(
+    HiGHS.Optimizer,
+    mode = BilevelJuMP.FortunyAmatMcCarlMode(primal_big_M = 100, dual_big_M = 100))
+
+@variable(Upper(model), 0 <= q <= 10)
+
+@variable(Lower(model), 0 <= r <= 10)
+
+# `r` is decided by the lower level, but the upper level is still free to use it:
+
+@objective(Upper(model), Min, q - 2r)
+
+# This sharing is what makes the problem bilevel. The leader optimizes over the
+# follower's response, so it has to be able to refer to the variables the
+# follower decides. Likewise the follower takes `q` as given, a parameter of its
+# own problem:
+
+@objective(Lower(model), Min, r)
+
+@constraint(Lower(model), q + r <= 8)
+
+optimize!(model)
+
+objective_value(model)
+
+# ## `UpperOnly`
+
+# `UpperOnly` creates a variable that only the upper level knows about. The
+# lower level cannot use it.
+
+# This changes the problem that is solved, rather than only stating intent. A
+# variable created with `Upper` enters the lower level problem as a parameter,
+# so it appears in the lower level optimality conditions that the reformulation
+# builds. An `UpperOnly` variable does not appear there at all.
+
+# Use it for leader decisions the follower must not react to:
+
+model = BilevelModel(
+    HiGHS.Optimizer,
+    mode = BilevelJuMP.FortunyAmatMcCarlMode(primal_big_M = 100, dual_big_M = 100))
+
+@variable(UpperOnly(model), 0 <= p <= 10)
+
+@variable(Upper(model), 0 <= q <= 10)
+
+@variable(Lower(model), 0 <= r <= 10)
+
+@objective(Upper(model), Min, p + q - 2r)
+
+@constraint(Upper(model), p + q >= 3)
+
+@objective(Lower(model), Min, r)
+
+@constraint(Lower(model), q + r <= 8)
+
+optimize!(model)
+
+value.([p, q, r])
+
+# ## `LowerOnly`
+
+# `LowerOnly` creates a variable that only the lower level knows about. The
+# upper level cannot use it, in its objective or in its constraints.
+
+# Use it for quantities that are internal to the follower, such as auxiliary or
+# slack variables that only exist to express the lower level problem. Declaring
+# them with `Lower` would also work, but `LowerOnly` states the intent and turns
+# an accidental use in the upper level into an error.
+
+model = BilevelModel(
+    HiGHS.Optimizer,
+    mode = BilevelJuMP.FortunyAmatMcCarlMode(primal_big_M = 100, dual_big_M = 100))
+
+@variable(Upper(model), 0 <= q <= 10)
+
+@variable(Lower(model), 0 <= r <= 10)
+
+@variable(LowerOnly(model), s >= 1)
+
+@objective(Upper(model), Min, q - 2r)
+
+@objective(Lower(model), Min, r + s)
+
+@constraint(Lower(model), q + r + s <= 8)
+
+optimize!(model)
+
+value.([q, r, s])
+
+# ## Levels are enforced
+
+# Using a variable in a level that cannot see it is an error, not a silent
+# reinterpretation. With the model above, `s` is known only to the lower level,
+# so putting it in the upper objective fails:
+
+# ```julia
+# @objective(Upper(model), Min, s)
+# # ERROR: Variable s belonging Only to LOWER_ONLY level, was added in the
+# # UPPER_ONLY level.
+# ```
+
+# The same holds the other way around for an `UpperOnly` variable used in a
+# lower level constraint.
+
+# !!! info
+#     `UpperOnly` and `LowerOnly` apply to variables only. Objectives and
+#     constraints are always added with `Upper` and `Lower`, which decide the
+#     level they belong to.
+
+# ## Querying variables per level
+
+# Whatever its level, every variable is part of the single `BilevelModel`, so
+# `value` works for all of them after a solve, and `all_variables` lists them
+# all:
+
+all_variables(model)
+
+# The level specific queries list only the variables that level can see, which
+# is a quick way to check a model is wired the way it was meant to be:
+
+all_variables(Upper(model))
+
+# Note that `s` is absent above, and present below:
+
+all_variables(Lower(model))
+
+# ## Summary
+
+# | constructor | decided by | visible to upper | visible to lower |
+# |:---|:---|:---|:---|
+# | `Upper(model)` | upper | yes | yes |
+# | `Lower(model)` | lower | yes | yes |
+# | `UpperOnly(model)` | upper | yes | no |
+# | `LowerOnly(model)` | lower | no | yes |
+
+# There is a fifth case, `DualOf`, for upper level variables that are the dual
+# of a lower level constraint. See
+# [Dual variables of the lower level](@ref) for that one.

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -328,6 +328,20 @@ end
 
 Create a special reference to the upper level of a bilevel model.
 Variables created with this reference will not be shared with the lower level.
+
+Unlike a variable created with [`Upper`](@ref), which the lower level sees
+as a parameter and which therefore appears in the lower level optimality
+conditions, a variable created here is invisible to the lower level. Using it
+in a lower level objective or constraint is an error.
+
+Use it for leader decisions the follower must not react to. See the
+[Variable levels](@ref) tutorial.
+
+## Example
+
+```julia
+@variable(UpperOnly(model), p >= 0)
+```
 """
 UpperOnly(m::BilevelModel) = UpperOnlyModel(m)
 struct LowerOnlyModel <: SingleBilevelModel
@@ -339,6 +353,20 @@ end
 
 Create a special reference to the lower level of a bilevel model.
 Variables created with this reference will not be shared with the upper level.
+
+Unlike a variable created with [`Lower`](@ref), which the upper level may
+still use in its objective and constraints, a variable created here is
+invisible to the upper level. Using it there is an error.
+
+Use it for quantities internal to the follower, such as auxiliary or slack
+variables that only exist to express the lower level problem. See the
+[Variable levels](@ref) tutorial.
+
+## Example
+
+```julia
+@variable(LowerOnly(model), s >= 1)
+```
 """
 LowerOnly(m::BilevelModel) = LowerOnlyModel(m)
 


### PR DESCRIPTION
Closes #181.

`UpperOnly` and `LowerOnly` were only listed by name in the API reference, with a one line docstring each, so neither what they do nor when to reach for them was written down anywhere.

### The tutorial

New page, `docs/src/tutorials/variable_levels.jl`, listed after Getting started.

The point that needs stating first is that **`Upper` and `Lower` both make a variable visible to the other level**. That sharing is what makes the problem bilevel: the leader has to be able to refer to what the follower decides. Only the two restricted constructors narrow that.

Against that baseline the two differ in kind, which is the "implications" half of the issue:

* **`UpperOnly` changes the problem being solved.** A variable created with `Upper` enters the lower level problem as a parameter, so it appears in the lower level optimality conditions the reformulation builds; an `UpperOnly` variable does not appear there at all. Use it for leader decisions the follower must not react to.

* **`LowerOnly` is mostly about intent.** Declaring an auxiliary or slack variable of the follower with `Lower` works just as well, but `LowerOnly` says so, and turns an accidental use in the upper level into an error rather than a silently different model.

Each section carries a model that is actually solved. The page closes with the per level `all_variables` queries and this table:

| constructor | decided by | visible to upper | visible to lower |
|:---|:---|:---|:---|
| `Upper(model)` | upper | yes | yes |
| `Lower(model)` | lower | yes | yes |
| `UpperOnly(model)` | upper | yes | no |
| `LowerOnly(model)` | lower | no | yes |

### Docstrings

`UpperOnly` and `LowerOnly` get the same distinction, since those are what the API reference renders and what `?UpperOnly` shows, with a link to the new tutorial. `reference.md` needed no change: it already lists both names.

### Verification

The behaviour documented here was checked against the code rather than paraphrased from the existing one line docstrings:

* `all_variables(Upper(model))` excludes a `LowerOnly` variable and `all_variables(Lower(model))` includes it, matching what the page claims.
* The error message quoted in the "Levels are enforced" section is the real one, checked verbatim.
* `UpperOnly`/`LowerOnly` are variables only — `@constraint(UpperOnly(m), ...)` is a `MethodError` — which the page notes.
* The tutorial runs under the same sandboxed `include` the docs build uses, and its Literate conversion renders correctly, table included.

### Note

I did not run JuliaFormatter over `docs/`: it wants to reformat 13 pre-existing files, and the format check only covers `src` and `test`. The new page follows the style of the neighbouring tutorials. `src` and `test` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
